### PR TITLE
Content management

### DIFF
--- a/.npmrc
+++ b/.npmrc
@@ -1,0 +1,8 @@
+# More options: https://docs.npmjs.com/misc/config
+
+# Dependencies saved to package.json will be configured with an exact version
+# rather than using npm's default semver range operator.
+save-exact=true
+
+# The base URL of the npm package registry.
+registry=http://registry.npm.ml.com/

--- a/config/default.js
+++ b/config/default.js
@@ -1,0 +1,10 @@
+module.exports = {
+  i18n: {
+    app: 'fury_credit-card-email-templates',
+    project: 'credits',
+    srcPath: `${__dirname}/../src/templates`,
+  },
+  assets: {
+    prefix: '/',
+  },
+};

--- a/i18n/es-AR/messages.po
+++ b/i18n/es-AR/messages.po
@@ -1,0 +1,7 @@
+msgid ""
+msgstr ""
+"Content-Type: text/plain; charset=UTF-8"
+
+msgid " "
+msgstr " "
+

--- a/i18n/es-MX/messages.po
+++ b/i18n/es-MX/messages.po
@@ -1,0 +1,7 @@
+msgid ""
+msgstr ""
+"Content-Type: text/plain; charset=UTF-8"
+
+msgid " "
+msgstr " "
+

--- a/i18n/messages.po
+++ b/i18n/messages.po
@@ -1,0 +1,26 @@
+# SOME DESCRIPTIVE TITLE.
+# Copyright (C) YEAR THE PACKAGE'S COPYRIGHT HOLDER
+# This file is distributed under the same license as the PACKAGE package.
+# FIRST AUTHOR <EMAIL@ADDRESS>, YEAR.
+#
+#, fuzzy
+msgid ""
+msgstr ""
+"Project-Id-Version: PACKAGE VERSION\n"
+"Report-Msgid-Bugs-To: \n"
+"POT-Creation-Date: 2020-07-07 13:41-0300\n"
+"PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
+"Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
+"Language-Team: LANGUAGE <LL@li.org>\n"
+"Language: \n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=CHARSET\n"
+"Content-Transfer-Encoding: 8bit\n"
+
+#: /Users/iguri/Repos/mail-webpack-test/config/../src/templates/one/content.js:30
+msgid "Un titulo muy apropiado"
+msgstr ""
+
+#: /Users/iguri/Repos/mail-webpack-test/config/../src/templates/one/content.js:31
+msgid "Dame tu CCB, maldito"
+msgstr ""

--- a/i18n/pt-BR/messages.po
+++ b/i18n/pt-BR/messages.po
@@ -1,0 +1,7 @@
+msgid ""
+msgstr ""
+"Content-Type: text/plain; charset=UTF-8"
+
+msgid " "
+msgstr " "
+

--- a/package-lock.json
+++ b/package-lock.json
@@ -777,6 +777,15 @@
         "@babel/helper-plugin-utils": "^7.10.1"
       }
     },
+    "@babel/plugin-transform-react-constant-elements": {
+      "version": "7.9.0",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-react-constant-elements/-/plugin-transform-react-constant-elements-7.9.0.tgz",
+      "integrity": "sha1-p1q8k2o4Ge3sQtM4bZ8ck/KNnZ4=",
+      "dev": true,
+      "requires": {
+        "@babel/helper-plugin-utils": "^7.8.3"
+      }
+    },
     "@babel/plugin-transform-react-display-name": {
       "version": "7.10.3",
       "resolved": "https://registry.npmjs.org/@babel/plugin-transform-react-display-name/-/plugin-transform-react-display-name-7.10.3.tgz",
@@ -784,6 +793,16 @@
       "dev": true,
       "requires": {
         "@babel/helper-plugin-utils": "^7.10.3"
+      }
+    },
+    "@babel/plugin-transform-react-inline-elements": {
+      "version": "7.9.0",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-react-inline-elements/-/plugin-transform-react-inline-elements-7.9.0.tgz",
+      "integrity": "sha1-GaOYQ0MYA3ZcmXYTIZi9je49gFg=",
+      "dev": true,
+      "requires": {
+        "@babel/helper-builder-react-jsx": "^7.9.0",
+        "@babel/helper-plugin-utils": "^7.8.3"
       }
     },
     "@babel/plugin-transform-react-jsx": {
@@ -1023,6 +1042,19 @@
         "@babel/plugin-transform-react-pure-annotations": "^7.10.1"
       }
     },
+    "@babel/register": {
+      "version": "7.9.0",
+      "resolved": "https://registry.npmjs.org/@babel/register/-/register-7.9.0.tgz",
+      "integrity": "sha1-AkZO3ldUi927Xp9wXSY7fD9D1Is=",
+      "dev": true,
+      "requires": {
+        "find-cache-dir": "^2.0.0",
+        "lodash": "^4.17.13",
+        "make-dir": "^2.1.0",
+        "pirates": "^4.0.0",
+        "source-map-support": "^0.5.16"
+      }
+    },
     "@babel/runtime": {
       "version": "7.10.3",
       "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.10.3.tgz",
@@ -1071,10 +1103,322 @@
         "to-fast-properties": "^2.0.0"
       }
     },
+    "@frontend-navigations/cb": {
+      "version": "2.0.0",
+      "resolved": "http://registry.npm.ml.com/@frontend-navigations/cb/-/cb-2.0.0.tgz",
+      "integrity": "sha1-HaoTCYSAnq1jQjAeuuOgEg7McB8=",
+      "dev": true,
+      "requires": {
+        "@frontend-navigations/commons": "1.1.4",
+        "@frontend-navigations/ml": "1.5.0",
+        "classnames": "2.2.6"
+      },
+      "dependencies": {
+        "@frontend-navigations/ml": {
+          "version": "1.5.0",
+          "resolved": "http://registry.npm.ml.com/@frontend-navigations/ml/-/ml-1.5.0.tgz",
+          "integrity": "sha1-YoGoUEnLI4vOYQLPqQ23lM+NA+E=",
+          "dev": true,
+          "requires": {
+            "@frontend-navigations/commons": "1.1.4",
+            "classnames": "2.2.6",
+            "nav-cart": "1.2.1",
+            "ui-navigation": "^5.3.7"
+          }
+        }
+      }
+    },
+    "@frontend-navigations/classi": {
+      "version": "1.0.3",
+      "resolved": "http://registry.npm.ml.com/@frontend-navigations/classi/-/classi-1.0.3.tgz",
+      "integrity": "sha1-SnTNH7o4f4cAkz57hj7a7Zog3N8=",
+      "dev": true,
+      "requires": {
+        "@frontend-navigations/commons": "1.1.4",
+        "@frontend-navigations/ml": "1.4.2",
+        "classnames": "2.2.6"
+      },
+      "dependencies": {
+        "@frontend-navigations/ml": {
+          "version": "1.4.2",
+          "resolved": "http://registry.npm.ml.com/@frontend-navigations/ml/-/ml-1.4.2.tgz",
+          "integrity": "sha1-yAya6kY/qO1ys/yjyFy7Gxf9k9k=",
+          "dev": true,
+          "requires": {
+            "@frontend-navigations/commons": "1.1.4",
+            "classnames": "2.2.6",
+            "nav-cart": "1.2.1",
+            "ui-navigation": "^5.3.7"
+          }
+        }
+      }
+    },
+    "@frontend-navigations/commons": {
+      "version": "1.1.4",
+      "resolved": "http://registry.npm.ml.com/@frontend-navigations/commons/-/commons-1.1.4.tgz",
+      "integrity": "sha1-eRecBqKjwamJjy3hvx0M7MVbEN4=",
+      "dev": true,
+      "requires": {
+        "frontend-logger": "^1.2.1",
+        "frontend-statsd": "^1.1.0"
+      }
+    },
+    "@frontend-navigations/first-party": {
+      "version": "1.0.1",
+      "resolved": "http://registry.npm.ml.com/@frontend-navigations/first-party/-/first-party-1.0.1.tgz",
+      "integrity": "sha1-om7QxuxK6Q8LcIlq67n5Wd7ua5U=",
+      "dev": true,
+      "requires": {
+        "@frontend-navigations/ml": "1.4.2"
+      },
+      "dependencies": {
+        "@frontend-navigations/ml": {
+          "version": "1.4.2",
+          "resolved": "http://registry.npm.ml.com/@frontend-navigations/ml/-/ml-1.4.2.tgz",
+          "integrity": "sha1-yAya6kY/qO1ys/yjyFy7Gxf9k9k=",
+          "dev": true,
+          "requires": {
+            "@frontend-navigations/commons": "1.1.4",
+            "classnames": "2.2.6",
+            "nav-cart": "1.2.1",
+            "ui-navigation": "^5.3.7"
+          }
+        }
+      }
+    },
+    "@frontend-navigations/ml": {
+      "version": "1.5.2",
+      "resolved": "http://registry.npm.ml.com/@frontend-navigations/ml/-/ml-1.5.2.tgz",
+      "integrity": "sha1-aciORmFGwU/VXAVJ1nsmt+J4RNU=",
+      "dev": true,
+      "requires": {
+        "@frontend-navigations/commons": "1.1.5",
+        "classnames": "2.2.6",
+        "nav-cart": "1.2.1",
+        "ui-navigation": "^5.3.7"
+      },
+      "dependencies": {
+        "@frontend-navigations/commons": {
+          "version": "1.1.5",
+          "resolved": "http://registry.npm.ml.com/@frontend-navigations/commons/-/commons-1.1.5.tgz",
+          "integrity": "sha1-ry+RGHjZTPGh1MWg0vb0oaMBXYw=",
+          "dev": true,
+          "requires": {
+            "frontend-logger": "^1.2.1",
+            "frontend-statsd": "^1.1.0"
+          }
+        }
+      }
+    },
+    "@frontend-navigations/mp": {
+      "version": "1.1.1",
+      "resolved": "http://registry.npm.ml.com/@frontend-navigations/mp/-/mp-1.1.1.tgz",
+      "integrity": "sha1-QaZTuKIk6zi/Qy/3HIqfreBIJ3U=",
+      "dev": true,
+      "requires": {
+        "@frontend-navigations/commons": "1.1.4",
+        "classnames": "2.2.6",
+        "frontend-config": "^1.31.0",
+        "ui-navigation": "^5.3.7"
+      }
+    },
+    "@frontend-navigations/ms": {
+      "version": "1.0.6",
+      "resolved": "http://registry.npm.ml.com/@frontend-navigations/ms/-/ms-1.0.6.tgz",
+      "integrity": "sha1-oSg0+YYSZ2lZRD9WCvUIEeNd7+Y=",
+      "dev": true,
+      "requires": {
+        "@frontend-navigations/commons": "1.1.4",
+        "html-react-parser": "0.10.1"
+      }
+    },
+    "@frontend-navigations/pi": {
+      "version": "1.0.4",
+      "resolved": "http://registry.npm.ml.com/@frontend-navigations/pi/-/pi-1.0.4.tgz",
+      "integrity": "sha1-GE1dYAP7bq/Trf9TkL3mWnrKmfw=",
+      "dev": true,
+      "requires": {
+        "@frontend-navigations/commons": "1.1.4",
+        "@frontend-navigations/ml": "1.4.2",
+        "classnames": "2.2.6"
+      },
+      "dependencies": {
+        "@frontend-navigations/ml": {
+          "version": "1.4.2",
+          "resolved": "http://registry.npm.ml.com/@frontend-navigations/ml/-/ml-1.4.2.tgz",
+          "integrity": "sha1-yAya6kY/qO1ys/yjyFy7Gxf9k9k=",
+          "dev": true,
+          "requires": {
+            "@frontend-navigations/commons": "1.1.4",
+            "classnames": "2.2.6",
+            "nav-cart": "1.2.1",
+            "ui-navigation": "^5.3.7"
+          }
+        }
+      }
+    },
+    "@frontend-performance/image-lazy-loading": {
+      "version": "1.3.0",
+      "resolved": "http://registry.npm.ml.com/@frontend-performance/image-lazy-loading/-/image-lazy-loading-1.3.0.tgz",
+      "integrity": "sha1-eNzZeFCdKGW+Wv9D1JDpigWk4AA=",
+      "dev": true
+    },
+    "@grpc/grpc-js": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/@grpc/grpc-js/-/grpc-js-1.0.3.tgz",
+      "integrity": "sha1-f6K6KTzMHpGyQHTCYoyMaDNuGMQ=",
+      "dev": true,
+      "requires": {
+        "semver": "^6.2.0"
+      },
+      "dependencies": {
+        "semver": {
+          "version": "6.3.0",
+          "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.0.tgz",
+          "integrity": "sha1-7gpkyK9ejO6mdoexM3YeG+y9HT0=",
+          "dev": true
+        }
+      }
+    },
+    "@grpc/proto-loader": {
+      "version": "0.5.4",
+      "resolved": "https://registry.npmjs.org/@grpc/proto-loader/-/proto-loader-0.5.4.tgz",
+      "integrity": "sha1-A4o4IFQPYh7rGwXYH77fsEXhTeA=",
+      "dev": true,
+      "requires": {
+        "lodash.camelcase": "^4.3.0",
+        "protobufjs": "^6.8.6"
+      }
+    },
+    "@meli/mobile-webkit": {
+      "version": "1.21.0",
+      "resolved": "http://registry.npm.ml.com/@meli/mobile-webkit/-/mobile-webkit-1.21.0.tgz",
+      "integrity": "sha1-36FnX6RtSo0Al2mKp2OJixuASPo=",
+      "dev": true
+    },
+    "@meli/node-caches": {
+      "version": "2.1.0",
+      "resolved": "http://registry.npm.ml.com/@meli/node-caches/-/node-caches-2.1.0.tgz",
+      "integrity": "sha1-oJRxP4XKZLEnNcc4DAGXmQQAT14=",
+      "dev": true,
+      "requires": {
+        "frontend-env": "^2.2.0",
+        "frontend-logger": "^1.2.1",
+        "frontend-statsd": "^1.1.4",
+        "kvsclient": "1.3.0",
+        "memcached": "2.2.2",
+        "stale-lru-cache": "5.1.1"
+      }
+    },
+    "@newrelic/aws-sdk": {
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/@newrelic/aws-sdk/-/aws-sdk-1.1.3.tgz",
+      "integrity": "sha1-5Rrc8M07WlJ7lqhqwkta2urByww=",
+      "dev": true
+    },
+    "@newrelic/koa": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/@newrelic/koa/-/koa-3.0.0.tgz",
+      "integrity": "sha1-BI9jbGwGq06CNnSi7T1nZ3oi7VA=",
+      "dev": true,
+      "requires": {
+        "methods": "^1.1.2"
+      }
+    },
+    "@newrelic/native-metrics": {
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/@newrelic/native-metrics/-/native-metrics-5.2.0.tgz",
+      "integrity": "sha1-21+wm8ULc9q+JiBinCTcn6kDpdU=",
+      "dev": true,
+      "optional": true,
+      "requires": {
+        "nan": "^2.14.1",
+        "semver": "^5.5.1"
+      }
+    },
+    "@newrelic/superagent": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/@newrelic/superagent/-/superagent-2.0.1.tgz",
+      "integrity": "sha1-igKAWY/t79G0X8g728JwfRKcR9U=",
+      "dev": true,
+      "requires": {
+        "methods": "^1.1.2"
+      }
+    },
+    "@protobufjs/aspromise": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/@protobufjs/aspromise/-/aspromise-1.1.2.tgz",
+      "integrity": "sha1-m4sMxmPWaafY9vXQiToU00jzD78=",
+      "dev": true
+    },
+    "@protobufjs/base64": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/@protobufjs/base64/-/base64-1.1.2.tgz",
+      "integrity": "sha1-TIVzDlm5ofHzSQR9vyQpYDS7JzU=",
+      "dev": true
+    },
+    "@protobufjs/codegen": {
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/@protobufjs/codegen/-/codegen-2.0.4.tgz",
+      "integrity": "sha1-fvN/DQEPsCitGtWXIuUG2SYoFcs=",
+      "dev": true
+    },
+    "@protobufjs/eventemitter": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@protobufjs/eventemitter/-/eventemitter-1.1.0.tgz",
+      "integrity": "sha1-NVy8mLr61ZePntCV85diHx0Ga3A=",
+      "dev": true
+    },
+    "@protobufjs/fetch": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@protobufjs/fetch/-/fetch-1.1.0.tgz",
+      "integrity": "sha1-upn7WYYUr2VwDBYZ/wbUVLDYTEU=",
+      "dev": true,
+      "requires": {
+        "@protobufjs/aspromise": "^1.1.1",
+        "@protobufjs/inquire": "^1.1.0"
+      }
+    },
+    "@protobufjs/float": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/@protobufjs/float/-/float-1.0.2.tgz",
+      "integrity": "sha1-Xp4avctz/Ap8uLKR33jIy9l7h9E=",
+      "dev": true
+    },
+    "@protobufjs/inquire": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@protobufjs/inquire/-/inquire-1.1.0.tgz",
+      "integrity": "sha1-/yAOPnzyQp4tyvwRQIKOjMY48Ik=",
+      "dev": true
+    },
+    "@protobufjs/path": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/@protobufjs/path/-/path-1.1.2.tgz",
+      "integrity": "sha1-bMKyDFya1q0NzP0hynZz2Nf79o0=",
+      "dev": true
+    },
+    "@protobufjs/pool": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@protobufjs/pool/-/pool-1.1.0.tgz",
+      "integrity": "sha1-Cf0V8tbTq/qbZbw2ZQbWrXhG/1Q=",
+      "dev": true
+    },
+    "@protobufjs/utf8": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@protobufjs/utf8/-/utf8-1.1.0.tgz",
+      "integrity": "sha1-p3c2C1s5oaLlEG+OhY8v0tBgxXA=",
+      "dev": true
+    },
     "@types/anymatch": {
       "version": "1.3.1",
       "resolved": "https://registry.npmjs.org/@types/anymatch/-/anymatch-1.3.1.tgz",
       "integrity": "sha512-/+CRPXpBDpo2RK9C68N3b2cOvO0Cf5B9aPijHsoDQTHivnGSObdOF2BRQOYjojWTDy6nQvMjmqRXIxH55VjxxA==",
+      "dev": true
+    },
+    "@types/domhandler": {
+      "version": "2.4.1",
+      "resolved": "https://registry.npmjs.org/@types/domhandler/-/domhandler-2.4.1.tgz",
+      "integrity": "sha1-ezs0f3diGA+8sezhzj3Q67uMZM8=",
       "dev": true
     },
     "@types/html-minifier-terser": {
@@ -1089,10 +1433,22 @@
       "integrity": "sha512-7+2BITlgjgDhH0vvwZU/HZJVyk+2XUlvxXe8dFMedNX/aMkaOq++rMAFXc0tM7ij15QaWlbdQASBR9dihi+bDQ==",
       "dev": true
     },
+    "@types/long": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/@types/long/-/long-4.0.1.tgz",
+      "integrity": "sha1-RZxl+hhn2v5qjzIsTFFpVmPMVek=",
+      "dev": true
+    },
     "@types/node": {
       "version": "14.0.14",
       "resolved": "https://registry.npmjs.org/@types/node/-/node-14.0.14.tgz",
       "integrity": "sha512-syUgf67ZQpaJj01/tRTknkMNoBBLWJOBODF0Zm4NrXmiSuxjymFrxnTu1QVYRubhVkRcZLYZG8STTwJRdVm/WQ==",
+      "dev": true
+    },
+    "@types/q": {
+      "version": "1.5.4",
+      "resolved": "https://registry.npmjs.org/@types/q/-/q-1.5.4.tgz",
+      "integrity": "sha1-FZJUFOCtLNdlv+9YhC9+JqesyyQ=",
       "dev": true
     },
     "@types/source-list-map": {
@@ -1164,6 +1520,12 @@
           "dev": true
         }
       }
+    },
+    "@tyriar/fibonacci-heap": {
+      "version": "2.0.9",
+      "resolved": "https://registry.npmjs.org/@tyriar/fibonacci-heap/-/fibonacci-heap-2.0.9.tgz",
+      "integrity": "sha1-3z3L2xuRghaGAfYxg2YVfuFmZuk=",
+      "dev": true
     },
     "@webassemblyjs/ast": {
       "version": "1.9.0",
@@ -1357,10 +1719,32 @@
       "resolved": "https://registry.npmjs.org/abbrev/-/abbrev-1.1.1.tgz",
       "integrity": "sha512-nne9/IiQ/hzIhY6pdDnbBtz7DjPTKrY00P/zvPSm5pOFkl6xuGrGnXn/VtTNNfNtAfZ9/1RtehkszU9qcTii0Q=="
     },
+    "accepts": {
+      "version": "1.3.7",
+      "resolved": "https://registry.npmjs.org/accepts/-/accepts-1.3.7.tgz",
+      "integrity": "sha1-UxvHJlF6OytB+FACHGzBXqq1B80=",
+      "dev": true,
+      "requires": {
+        "mime-types": "~2.1.24",
+        "negotiator": "0.6.2"
+      }
+    },
     "acorn": {
       "version": "6.4.1",
       "resolved": "https://registry.npmjs.org/acorn/-/acorn-6.4.1.tgz",
       "integrity": "sha512-ZVA9k326Nwrj3Cj9jlh3wGFutC2ZornPNARZwsNYqQYgN0EsV2d53w5RN/co65Ohn4sUAUtb1rSUAOD6XN9idA==",
+      "dev": true
+    },
+    "adm-zip": {
+      "version": "0.4.13",
+      "resolved": "https://registry.npmjs.org/adm-zip/-/adm-zip-0.4.13.tgz",
+      "integrity": "sha1-WX4vjMNnIVHhMH0+lc3bx1ZyMUo=",
+      "dev": true
+    },
+    "agent-base": {
+      "version": "5.1.1",
+      "resolved": "https://registry.npmjs.org/agent-base/-/agent-base-5.1.1.tgz",
+      "integrity": "sha1-6Ps/JClZ20TWO+Zl23qOc5U3oyw=",
       "dev": true
     },
     "ajv": {
@@ -1415,6 +1799,17 @@
         "picomatch": "^2.0.4"
       }
     },
+    "aphrodite": {
+      "version": "2.4.0",
+      "resolved": "https://registry.npmjs.org/aphrodite/-/aphrodite-2.4.0.tgz",
+      "integrity": "sha1-7Boq+kG6cxCkek8fuieRnZlXLJE=",
+      "dev": true,
+      "requires": {
+        "asap": "^2.0.3",
+        "inline-style-prefixer": "^5.1.0",
+        "string-hash": "^1.1.3"
+      }
+    },
     "app-root-path": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/app-root-path/-/app-root-path-3.0.0.tgz",
@@ -1459,6 +1854,15 @@
         }
       }
     },
+    "argparse": {
+      "version": "1.0.10",
+      "resolved": "https://registry.npmjs.org/argparse/-/argparse-1.0.10.tgz",
+      "integrity": "sha1-vNZ5HqWuCXJeF+WtmIE0zUCz2RE=",
+      "dev": true,
+      "requires": {
+        "sprintf-js": "~1.0.2"
+      }
+    },
     "arr-diff": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/arr-diff/-/arr-diff-4.0.0.tgz",
@@ -1482,10 +1886,22 @@
       "resolved": "https://registry.npmjs.org/array-find-index/-/array-find-index-1.0.2.tgz",
       "integrity": "sha1-3wEKoSh+Fku9pvlyOwqWoexBh6E="
     },
+    "array-flatten": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/array-flatten/-/array-flatten-1.1.1.tgz",
+      "integrity": "sha1-ml9pkFGx5wczKPKgCJaLZOopVdI=",
+      "dev": true
+    },
     "array-unique": {
       "version": "0.3.2",
       "resolved": "https://registry.npmjs.org/array-unique/-/array-unique-0.3.2.tgz",
       "integrity": "sha1-qJS3XUvE9s1nnvMkSp/Y9Gri1Cg=",
+      "dev": true
+    },
+    "asap": {
+      "version": "2.0.6",
+      "resolved": "https://registry.npmjs.org/asap/-/asap-2.0.6.tgz",
+      "integrity": "sha1-5QNHYR1+aQlDIIu9r+vLwvuGbUY=",
       "dev": true
     },
     "asn1": {
@@ -2631,6 +3047,15 @@
       "integrity": "sha512-mLQ4i2QO1ytvGWFWmcngKO//JXAQueZvwEKtjgQFM4jIK0kU+ytMfplL8j+n5mspOfjHwoAg+9yhb7BwAHm36g==",
       "dev": true
     },
+    "basic-auth": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/basic-auth/-/basic-auth-2.0.1.tgz",
+      "integrity": "sha1-uZgnm/R844NEtPPPkW1Gebv1Hjo=",
+      "dev": true,
+      "requires": {
+        "safe-buffer": "5.1.2"
+      }
+    },
     "bcrypt-pbkdf": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/bcrypt-pbkdf/-/bcrypt-pbkdf-1.0.2.tgz",
@@ -2682,10 +3107,76 @@
       "integrity": "sha512-40rZaf3bUNKTVYu9sIeeEGOg7g14Yvnj9kH7b50EiwX0Q7A6umbvfI5tvHaOERH0XigqKkfLkFQxzb4e6CIXnA==",
       "dev": true
     },
+    "body-parser": {
+      "version": "1.19.0",
+      "resolved": "https://registry.npmjs.org/body-parser/-/body-parser-1.19.0.tgz",
+      "integrity": "sha1-lrJwnlfJxOCab9Zqj9l5hE9p8Io=",
+      "dev": true,
+      "requires": {
+        "bytes": "3.1.0",
+        "content-type": "~1.0.4",
+        "debug": "2.6.9",
+        "depd": "~1.1.2",
+        "http-errors": "1.7.2",
+        "iconv-lite": "0.4.24",
+        "on-finished": "~2.3.0",
+        "qs": "6.7.0",
+        "raw-body": "2.4.0",
+        "type-is": "~1.6.17"
+      },
+      "dependencies": {
+        "debug": {
+          "version": "2.6.9",
+          "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
+          "integrity": "sha1-XRKFFd8TT/Mn6QpMk/Tgd6U2NB8=",
+          "dev": true,
+          "requires": {
+            "ms": "2.0.0"
+          }
+        },
+        "http-errors": {
+          "version": "1.7.2",
+          "resolved": "https://registry.npmjs.org/http-errors/-/http-errors-1.7.2.tgz",
+          "integrity": "sha1-T1ApzxMjnzEDblsuVSkrz7zIXI8=",
+          "dev": true,
+          "requires": {
+            "depd": "~1.1.2",
+            "inherits": "2.0.3",
+            "setprototypeof": "1.1.1",
+            "statuses": ">= 1.5.0 < 2",
+            "toidentifier": "1.0.0"
+          }
+        },
+        "inherits": {
+          "version": "2.0.3",
+          "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.3.tgz",
+          "integrity": "sha1-Yzwsg+PaQqUC9SRmAiSA9CCCYd4=",
+          "dev": true
+        },
+        "ms": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
+          "integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g=",
+          "dev": true
+        },
+        "qs": {
+          "version": "6.7.0",
+          "resolved": "https://registry.npmjs.org/qs/-/qs-6.7.0.tgz",
+          "integrity": "sha1-QdwaAV49WB8WIXdr4xr7KHapsbw=",
+          "dev": true
+        }
+      }
+    },
     "boolbase": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/boolbase/-/boolbase-1.0.0.tgz",
       "integrity": "sha1-aN/1++YMUes3cl6p4+0xDcwed24="
+    },
+    "bowser": {
+      "version": "2.9.0",
+      "resolved": "https://registry.npmjs.org/bowser/-/bowser-2.9.0.tgz",
+      "integrity": "sha1-O+2FQjO0GbmnQi2e4+hVBDc4Ick=",
+      "dev": true
     },
     "brace-expansion": {
       "version": "1.1.11",
@@ -2867,6 +3358,12 @@
       "integrity": "sha1-hZgoeOIbmOHGZCXgPQF0eI9Wnug=",
       "dev": true
     },
+    "bytes": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/bytes/-/bytes-3.1.0.tgz",
+      "integrity": "sha1-9s95M6Ng4FiPqf3oVlHNx/gF0fY=",
+      "dev": true
+    },
     "cacache": {
       "version": "12.0.4",
       "resolved": "https://registry.npmjs.org/cacache/-/cacache-12.0.4.tgz",
@@ -2938,6 +3435,12 @@
         }
       }
     },
+    "camelize": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/camelize/-/camelize-1.0.0.tgz",
+      "integrity": "sha1-FkpUg+Yw+kMh5a8HAg5TGDGyYJs=",
+      "dev": true
+    },
     "caniuse-lite": {
       "version": "1.0.30001090",
       "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001090.tgz",
@@ -2948,6 +3451,58 @@
       "version": "0.12.0",
       "resolved": "https://registry.npmjs.org/caseless/-/caseless-0.12.0.tgz",
       "integrity": "sha1-G2gcIf+EAzyCZUMJBolCDRhxUdw="
+    },
+    "cbt-users-middleware": {
+      "version": "1.1.1",
+      "resolved": "http://registry.npm.ml.com/cbt-users-middleware/-/cbt-users-middleware-1.1.1.tgz",
+      "integrity": "sha1-wHLctQt8/a66duGmpxkXvWlK0ZQ=",
+      "dev": true,
+      "requires": {
+        "frontend-env": "^2.3.0",
+        "frontend-restclient": "^2.10.0"
+      },
+      "dependencies": {
+        "frontend-restclient": {
+          "version": "2.10.0",
+          "resolved": "http://registry.npm.ml.com/frontend-restclient/-/frontend-restclient-2.10.0.tgz",
+          "integrity": "sha1-z2oUCtrboEANzE/70sPqJ39f+cM=",
+          "dev": true,
+          "requires": {
+            "@meli/node-caches": "^2.0.2",
+            "frontend-env": "^2.0.0",
+            "frontend-logger": "^1.0.0",
+            "frontend-statsd": "^1.1.2",
+            "newrelic": "*",
+            "nordic-axios": "2.0.0",
+            "retry": "0.12.0",
+            "stack-trace": "0.0.10",
+            "stale-lru-cache": "5.1.1",
+            "uuid": "3.3.3"
+          }
+        },
+        "is-buffer": {
+          "version": "2.0.4",
+          "resolved": "https://registry.npmjs.org/is-buffer/-/is-buffer-2.0.4.tgz",
+          "integrity": "sha1-PlcvI8hBGlz9lVfISeNmXgspBiM=",
+          "dev": true
+        },
+        "nordic-axios": {
+          "version": "2.0.0",
+          "resolved": "http://registry.npm.ml.com/nordic-axios/-/nordic-axios-2.0.0.tgz",
+          "integrity": "sha1-pAJVjVpjmqZeVqv33w3D0e/fmoM=",
+          "dev": true,
+          "requires": {
+            "follow-redirects": "1.5.10",
+            "is-buffer": "^2.0.2"
+          }
+        },
+        "uuid": {
+          "version": "3.3.3",
+          "resolved": "https://registry.npmjs.org/uuid/-/uuid-3.3.3.tgz",
+          "integrity": "sha1-RWjwIW54dg7h2/Ok0s9T4iQRKGY=",
+          "dev": true
+        }
+      }
     },
     "chalk": {
       "version": "2.4.2",
@@ -3137,6 +3692,12 @@
         }
       }
     },
+    "classnames": {
+      "version": "2.2.6",
+      "resolved": "https://registry.npmjs.org/classnames/-/classnames-2.2.6.tgz",
+      "integrity": "sha1-Q5Nb/90pHzJtrQogUwmzjQD2UM4=",
+      "dev": true
+    },
     "clean-css": {
       "version": "4.2.3",
       "resolved": "https://registry.npmjs.org/clean-css/-/clean-css-4.2.3.tgz",
@@ -3179,6 +3740,12 @@
         }
       }
     },
+    "clone": {
+      "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/clone/-/clone-0.2.0.tgz",
+      "integrity": "sha1-xhJqkK1Pctv1rNskPMN3JP6T/B8=",
+      "dev": true
+    },
     "clone-deep": {
       "version": "4.0.1",
       "resolved": "https://registry.npmjs.org/clone-deep/-/clone-deep-4.0.1.tgz",
@@ -3188,6 +3755,17 @@
         "is-plain-object": "^2.0.4",
         "kind-of": "^6.0.2",
         "shallow-clone": "^3.0.0"
+      }
+    },
+    "coa": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/coa/-/coa-2.0.2.tgz",
+      "integrity": "sha1-Q/bCEVG07yv1cYfbDXPeIp4+fsM=",
+      "dev": true,
+      "requires": {
+        "@types/q": "^1.5.1",
+        "chalk": "^2.4.1",
+        "q": "^1.1.2"
       }
     },
     "code-point-at": {
@@ -3205,6 +3783,16 @@
         "object-visit": "^1.0.0"
       }
     },
+    "color": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/color/-/color-3.0.0.tgz",
+      "integrity": "sha1-2SC0Mo1TSjrIKV1o971LpsQnvpo=",
+      "dev": true,
+      "requires": {
+        "color-convert": "^1.9.1",
+        "color-string": "^1.5.2"
+      }
+    },
     "color-convert": {
       "version": "1.9.3",
       "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-1.9.3.tgz",
@@ -3217,6 +3805,38 @@
       "version": "1.1.3",
       "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.3.tgz",
       "integrity": "sha1-p9BVi9icQveV3UIyj3QIMcpTvCU="
+    },
+    "color-string": {
+      "version": "1.5.3",
+      "resolved": "https://registry.npmjs.org/color-string/-/color-string-1.5.3.tgz",
+      "integrity": "sha1-ybvF8BtYtUkvPWhXRZy2WQziBMw=",
+      "dev": true,
+      "requires": {
+        "color-name": "^1.0.0",
+        "simple-swizzle": "^0.2.2"
+      }
+    },
+    "colornames": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/colornames/-/colornames-1.1.1.tgz",
+      "integrity": "sha1-+IiQMGhcfE/54qVZ9Qd+t2qBb5Y=",
+      "dev": true
+    },
+    "colors": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/colors/-/colors-1.4.0.tgz",
+      "integrity": "sha1-xQSRR51MG9rtLJztMs98fcI2D3g=",
+      "dev": true
+    },
+    "colorspace": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/colorspace/-/colorspace-1.1.2.tgz",
+      "integrity": "sha1-4BKJUNCCuGohaFgHlqCqXWxo2MU=",
+      "dev": true,
+      "requires": {
+        "color": "3.0.x",
+        "text-hex": "1.0.x"
+      }
     },
     "combined-stream": {
       "version": "1.0.8",
@@ -3243,6 +3863,53 @@
       "resolved": "https://registry.npmjs.org/component-emitter/-/component-emitter-1.3.0.tgz",
       "integrity": "sha512-Rd3se6QB+sO1TwqZjscQrurpEPIfO0/yYnSin6Q/rD3mOutHvUrCAhJub3r90uNb+SESBuE0QYoB90YdfatsRg==",
       "dev": true
+    },
+    "compressible": {
+      "version": "2.0.18",
+      "resolved": "https://registry.npmjs.org/compressible/-/compressible-2.0.18.tgz",
+      "integrity": "sha1-r1PMprBw1MPAdQ+9dyhqbXzEb7o=",
+      "dev": true,
+      "requires": {
+        "mime-db": ">= 1.43.0 < 2"
+      }
+    },
+    "compression": {
+      "version": "1.7.4",
+      "resolved": "https://registry.npmjs.org/compression/-/compression-1.7.4.tgz",
+      "integrity": "sha1-lVI+/xcMpXwpoMpB5v4TH0Hlu48=",
+      "dev": true,
+      "requires": {
+        "accepts": "~1.3.5",
+        "bytes": "3.0.0",
+        "compressible": "~2.0.16",
+        "debug": "2.6.9",
+        "on-headers": "~1.0.2",
+        "safe-buffer": "5.1.2",
+        "vary": "~1.1.2"
+      },
+      "dependencies": {
+        "bytes": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/bytes/-/bytes-3.0.0.tgz",
+          "integrity": "sha1-0ygVQE1olpn4Wk6k+odV3ROpYEg=",
+          "dev": true
+        },
+        "debug": {
+          "version": "2.6.9",
+          "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
+          "integrity": "sha1-XRKFFd8TT/Mn6QpMk/Tgd6U2NB8=",
+          "dev": true,
+          "requires": {
+            "ms": "2.0.0"
+          }
+        },
+        "ms": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
+          "integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g=",
+          "dev": true
+        }
+      }
     },
     "concat-map": {
       "version": "0.0.1",
@@ -3287,6 +3954,69 @@
         }
       }
     },
+    "condense-newlines": {
+      "version": "0.2.1",
+      "resolved": "https://registry.npmjs.org/condense-newlines/-/condense-newlines-0.2.1.tgz",
+      "integrity": "sha1-PemFVTE5R10yUCyDsC9gaE0kxV8=",
+      "dev": true,
+      "requires": {
+        "extend-shallow": "^2.0.1",
+        "is-whitespace": "^0.3.0",
+        "kind-of": "^3.0.2"
+      },
+      "dependencies": {
+        "extend-shallow": {
+          "version": "2.0.1",
+          "resolved": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-2.0.1.tgz",
+          "integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
+          "dev": true,
+          "requires": {
+            "is-extendable": "^0.1.0"
+          }
+        },
+        "kind-of": {
+          "version": "3.2.2",
+          "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
+          "integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
+          "dev": true,
+          "requires": {
+            "is-buffer": "^1.1.5"
+          }
+        }
+      }
+    },
+    "config-chain": {
+      "version": "1.1.12",
+      "resolved": "https://registry.npmjs.org/config-chain/-/config-chain-1.1.12.tgz",
+      "integrity": "sha1-D96NCRIA616AjK8l/mGMAvSOTvo=",
+      "dev": true,
+      "requires": {
+        "ini": "^1.3.4",
+        "proto-list": "~1.2.1"
+      }
+    },
+    "connect-flash": {
+      "version": "0.1.1",
+      "resolved": "https://registry.npmjs.org/connect-flash/-/connect-flash-0.1.1.tgz",
+      "integrity": "sha1-2GMPJtlaf4UfmVax6MxnMvO2qjA=",
+      "dev": true
+    },
+    "connect-kvs": {
+      "version": "1.4.2",
+      "resolved": "http://registry.npm.ml.com/connect-kvs/-/connect-kvs-1.4.2.tgz",
+      "integrity": "sha1-+0UidaevNGzwJlu2CeBarm8Q+kU=",
+      "dev": true,
+      "requires": {
+        "frontend-statsd": "^1.1.0",
+        "kvsclient": "^1.3.0"
+      }
+    },
+    "connection-parse": {
+      "version": "0.0.7",
+      "resolved": "https://registry.npmjs.org/connection-parse/-/connection-parse-0.0.7.tgz",
+      "integrity": "sha1-GOcxiqsGppkmc3KxDFIm0locmmk=",
+      "dev": true
+    },
     "console-browserify": {
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/console-browserify/-/console-browserify-1.2.0.tgz",
@@ -3304,6 +4034,27 @@
       "integrity": "sha1-wguW2MYXdIqvHBYCF2DNJ/y4y3U=",
       "dev": true
     },
+    "content-disposition": {
+      "version": "0.5.3",
+      "resolved": "https://registry.npmjs.org/content-disposition/-/content-disposition-0.5.3.tgz",
+      "integrity": "sha1-4TDK9+cnkIfFYWwgB9BIVpiYT70=",
+      "dev": true,
+      "requires": {
+        "safe-buffer": "5.1.2"
+      }
+    },
+    "content-security-policy-builder": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/content-security-policy-builder/-/content-security-policy-builder-2.1.0.tgz",
+      "integrity": "sha1-CiNk12mj1wFO7Hn/dpmATeuM/Ls=",
+      "dev": true
+    },
+    "content-type": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/content-type/-/content-type-1.0.4.tgz",
+      "integrity": "sha1-4TjMdeBAxyexlm/l5fjJruJW/js=",
+      "dev": true
+    },
     "convert-source-map": {
       "version": "1.7.0",
       "resolved": "https://registry.npmjs.org/convert-source-map/-/convert-source-map-1.7.0.tgz",
@@ -3312,6 +4063,36 @@
       "requires": {
         "safe-buffer": "~5.1.1"
       }
+    },
+    "cookie": {
+      "version": "0.4.0",
+      "resolved": "https://registry.npmjs.org/cookie/-/cookie-0.4.0.tgz",
+      "integrity": "sha1-vrQ35wIrO21JAZ0IhmUwPr6cFLo=",
+      "dev": true
+    },
+    "cookie-parser": {
+      "version": "1.4.4",
+      "resolved": "https://registry.npmjs.org/cookie-parser/-/cookie-parser-1.4.4.tgz",
+      "integrity": "sha1-5jY95OqYw975aXuTQhwJ8wz10Yg=",
+      "dev": true,
+      "requires": {
+        "cookie": "0.3.1",
+        "cookie-signature": "1.0.6"
+      },
+      "dependencies": {
+        "cookie": {
+          "version": "0.3.1",
+          "resolved": "https://registry.npmjs.org/cookie/-/cookie-0.3.1.tgz",
+          "integrity": "sha1-5+Ch+e9DtMi6klxcWpboBtFoc7s=",
+          "dev": true
+        }
+      }
+    },
+    "cookie-signature": {
+      "version": "1.0.6",
+      "resolved": "https://registry.npmjs.org/cookie-signature/-/cookie-signature-1.0.6.tgz",
+      "integrity": "sha1-4wOogrNCzD7oylE6eZmXNNqzriw=",
+      "dev": true
     },
     "copy-concurrently": {
       "version": "1.0.5",
@@ -3438,6 +4219,27 @@
         "randomfill": "^1.0.3"
       }
     },
+    "csrf": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/csrf/-/csrf-3.1.0.tgz",
+      "integrity": "sha1-7HXpZW0ATWdLjvW6R7Qfv9bLnDA=",
+      "dev": true,
+      "requires": {
+        "rndm": "1.2.0",
+        "tsscmp": "1.0.6",
+        "uid-safe": "2.1.5"
+      }
+    },
+    "css-in-js-utils": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/css-in-js-utils/-/css-in-js-utils-2.0.1.tgz",
+      "integrity": "sha1-O0crOYeHKRtHz+PkT+z92ekUupk=",
+      "dev": true,
+      "requires": {
+        "hyphenate-style-name": "^1.0.2",
+        "isobject": "^3.0.1"
+      }
+    },
     "css-loader": {
       "version": "3.6.0",
       "resolved": "https://registry.npmjs.org/css-loader/-/css-loader-3.6.0.tgz",
@@ -3514,6 +4316,22 @@
         }
       }
     },
+    "css-select-base-adapter": {
+      "version": "0.1.1",
+      "resolved": "https://registry.npmjs.org/css-select-base-adapter/-/css-select-base-adapter-0.1.1.tgz",
+      "integrity": "sha1-Oy/0lyzDYquIVhUHqVQIoUMhNdc=",
+      "dev": true
+    },
+    "css-tree": {
+      "version": "1.0.0-alpha.33",
+      "resolved": "https://registry.npmjs.org/css-tree/-/css-tree-1.0.0-alpha.33.tgz",
+      "integrity": "sha1-lw4g5akfejeN3Q/FjQtsjU876T4=",
+      "dev": true,
+      "requires": {
+        "mdn-data": "2.0.4",
+        "source-map": "^0.5.3"
+      }
+    },
     "css-what": {
       "version": "2.1.3",
       "resolved": "https://registry.npmjs.org/css-what/-/css-what-2.1.3.tgz",
@@ -3525,6 +4343,51 @@
       "integrity": "sha512-/Tb/JcjK111nNScGob5MNtsntNM1aCNUDipB/TkwZFhyDrrE47SOx/18wF2bbjgc3ZzCSKW1T5nt5EbFoAz/Vg==",
       "dev": true
     },
+    "cssfilter": {
+      "version": "0.0.10",
+      "resolved": "https://registry.npmjs.org/cssfilter/-/cssfilter-0.0.10.tgz",
+      "integrity": "sha1-xtJnJjKi5cg+AT5oZKQs6N79IK4=",
+      "dev": true
+    },
+    "csso": {
+      "version": "3.5.1",
+      "resolved": "https://registry.npmjs.org/csso/-/csso-3.5.1.tgz",
+      "integrity": "sha1-e564vmFiiXPBsmHhadLwJACOdYs=",
+      "dev": true,
+      "requires": {
+        "css-tree": "1.0.0-alpha.29"
+      },
+      "dependencies": {
+        "css-tree": {
+          "version": "1.0.0-alpha.29",
+          "resolved": "https://registry.npmjs.org/css-tree/-/css-tree-1.0.0-alpha.29.tgz",
+          "integrity": "sha1-P6nU7zFCy9HDAedmTB81K9gvWjk=",
+          "dev": true,
+          "requires": {
+            "mdn-data": "~1.1.0",
+            "source-map": "^0.5.3"
+          }
+        },
+        "mdn-data": {
+          "version": "1.1.4",
+          "resolved": "https://registry.npmjs.org/mdn-data/-/mdn-data-1.1.4.tgz",
+          "integrity": "sha1-ULXU/8RXUnZXPE7tuHgIEqhBnwE=",
+          "dev": true
+        }
+      }
+    },
+    "csurf": {
+      "version": "1.11.0",
+      "resolved": "https://registry.npmjs.org/csurf/-/csurf-1.11.0.tgz",
+      "integrity": "sha1-qww8ZjRjQZK9PW9LhhviCADutho=",
+      "dev": true,
+      "requires": {
+        "cookie": "0.4.0",
+        "cookie-signature": "1.0.6",
+        "csrf": "3.1.0",
+        "http-errors": "~1.7.3"
+      }
+    },
     "currently-unhandled": {
       "version": "0.4.1",
       "resolved": "https://registry.npmjs.org/currently-unhandled/-/currently-unhandled-0.4.1.tgz",
@@ -3532,6 +4395,12 @@
       "requires": {
         "array-find-index": "^1.0.1"
       }
+    },
+    "cycle": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/cycle/-/cycle-1.0.3.tgz",
+      "integrity": "sha1-IegLK+hYD5i0aPN5QwZisEbDStI=",
+      "dev": true
     },
     "cyclist": {
       "version": "1.0.1",
@@ -3547,6 +4416,12 @@
         "assert-plus": "^1.0.0"
       }
     },
+    "dasherize": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/dasherize/-/dasherize-2.0.0.tgz",
+      "integrity": "sha1-bYCcnNDPe7iVLYD8hPoT1H3bEwg=",
+      "dev": true
+    },
     "datauri": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/datauri/-/datauri-2.0.0.tgz",
@@ -3555,6 +4430,12 @@
         "image-size": "^0.7.3",
         "mimer": "^1.0.0"
       }
+    },
+    "dateformat": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/dateformat/-/dateformat-3.0.3.tgz",
+      "integrity": "sha1-puN0maTZqc+F71hyBE1ikByYia4=",
+      "dev": true
     },
     "debug": {
       "version": "4.1.1",
@@ -3580,6 +4461,12 @@
       "version": "0.6.0",
       "resolved": "https://registry.npmjs.org/deep-extend/-/deep-extend-0.6.0.tgz",
       "integrity": "sha512-LOHxIOaPYdHlJRtCQfDIVZtfw/ufM8+rVj649RIHzcm/vGwQRXFt6OPqIFWsm2XEMrNIEtWR64sY1LEKD2vAOA=="
+    },
+    "deep-is": {
+      "version": "0.1.3",
+      "resolved": "https://registry.npmjs.org/deep-is/-/deep-is-0.1.3.tgz",
+      "integrity": "sha1-s2nW+128E+7PUk+RsHD+7cNXzzQ=",
+      "dev": true
     },
     "define-properties": {
       "version": "1.1.3",
@@ -3641,6 +4528,12 @@
       "resolved": "https://registry.npmjs.org/delegates/-/delegates-1.0.0.tgz",
       "integrity": "sha1-hMbhWbgZBP3KWaDvRM2HDTElD5o="
     },
+    "depd": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/depd/-/depd-1.1.2.tgz",
+      "integrity": "sha1-m81S4UwJd2PnSbJ0xDRu0uVgtak=",
+      "dev": true
+    },
     "des.js": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/des.js/-/des.js-1.0.1.tgz",
@@ -3650,6 +4543,12 @@
         "inherits": "^2.0.1",
         "minimalistic-assert": "^1.0.0"
       }
+    },
+    "destroy": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/destroy/-/destroy-1.0.4.tgz",
+      "integrity": "sha1-l4hXRCxEdJ5CBmE+N5RiBYJqvYA=",
+      "dev": true
     },
     "detect-file": {
       "version": "1.0.0",
@@ -3664,6 +4563,17 @@
       "dev": true,
       "requires": {
         "repeating": "^2.0.0"
+      }
+    },
+    "diagnostics": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/diagnostics/-/diagnostics-1.1.1.tgz",
+      "integrity": "sha1-yrasM99wydmnJ0kK5DrJladpsio=",
+      "dev": true,
+      "requires": {
+        "colorspace": "1.1.x",
+        "enabled": "1.0.x",
+        "kuler": "1.0.x"
       }
     },
     "diffie-hellman": {
@@ -3684,6 +4594,12 @@
           "dev": true
         }
       }
+    },
+    "dns-prefetch-control": {
+      "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/dns-prefetch-control/-/dns-prefetch-control-0.2.0.tgz",
+      "integrity": "sha1-c5iBYYQfPcyB9HaG1TmixwLIhiQ=",
+      "dev": true
     },
     "dom-converter": {
       "version": "0.2.0",
@@ -3731,6 +4647,12 @@
         "domelementtype": "^2.0.1",
         "domhandler": "^3.0.0"
       }
+    },
+    "dont-sniff-mimetype": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/dont-sniff-mimetype/-/dont-sniff-mimetype-1.1.0.tgz",
+      "integrity": "sha1-x9BCf4vLCVdidRJSr1nRSLCmI7I=",
+      "dev": true
     },
     "dot-case": {
       "version": "3.0.3",
@@ -3789,6 +4711,48 @@
         "safer-buffer": "^2.1.0"
       }
     },
+    "editorconfig": {
+      "version": "0.15.3",
+      "resolved": "https://registry.npmjs.org/editorconfig/-/editorconfig-0.15.3.tgz",
+      "integrity": "sha1-vvhMTnX7jcsM5c7o79UcFZmb78U=",
+      "dev": true,
+      "requires": {
+        "commander": "^2.19.0",
+        "lru-cache": "^4.1.5",
+        "semver": "^5.6.0",
+        "sigmund": "^1.0.1"
+      },
+      "dependencies": {
+        "commander": {
+          "version": "2.20.3",
+          "resolved": "https://registry.npmjs.org/commander/-/commander-2.20.3.tgz",
+          "integrity": "sha1-/UhehMA+tIgcIHIrpIA16FMa6zM=",
+          "dev": true
+        },
+        "lru-cache": {
+          "version": "4.1.5",
+          "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-4.1.5.tgz",
+          "integrity": "sha1-i75Q6oW+1ZvJ4z3KuCNe6bz0Q80=",
+          "dev": true,
+          "requires": {
+            "pseudomap": "^1.0.2",
+            "yallist": "^2.1.2"
+          }
+        },
+        "yallist": {
+          "version": "2.1.2",
+          "resolved": "https://registry.npmjs.org/yallist/-/yallist-2.1.2.tgz",
+          "integrity": "sha1-HBH5IY8HYImkfdUS+TxmmaaoHVI=",
+          "dev": true
+        }
+      }
+    },
+    "ee-first": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/ee-first/-/ee-first-1.1.1.tgz",
+      "integrity": "sha1-WQxhFWsK4vTwJVcyoViyZrxWsh0=",
+      "dev": true
+    },
     "electron-to-chromium": {
       "version": "1.3.483",
       "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.3.483.tgz",
@@ -3828,6 +4792,30 @@
       "resolved": "https://registry.npmjs.org/emojis-list/-/emojis-list-3.0.0.tgz",
       "integrity": "sha512-/kyM18EfinwXZbno9FyUGeFh87KC8HRQBQGildHZbEuRyWFOmv1U10o9BBp8XVZDVNNuQKyIGIu5ZYAAXJ0V2Q==",
       "dev": true
+    },
+    "enabled": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/enabled/-/enabled-1.0.2.tgz",
+      "integrity": "sha1-ll9lE9LC0cX0ZStkouM5ZGf8L5M=",
+      "dev": true,
+      "requires": {
+        "env-variable": "0.0.x"
+      }
+    },
+    "encodeurl": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/encodeurl/-/encodeurl-1.0.2.tgz",
+      "integrity": "sha1-rT/0yG7C0CkyL1oCw6mmBslbP1k=",
+      "dev": true
+    },
+    "encoding": {
+      "version": "0.1.12",
+      "resolved": "https://registry.npmjs.org/encoding/-/encoding-0.1.12.tgz",
+      "integrity": "sha1-U4tm8+5izRq1HsMjgp0flIDHS+s=",
+      "dev": true,
+      "requires": {
+        "iconv-lite": "~0.4.13"
+      }
     },
     "end-of-stream": {
       "version": "1.4.4",
@@ -3885,10 +4873,22 @@
         }
       }
     },
+    "ent": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/ent/-/ent-2.2.0.tgz",
+      "integrity": "sha1-6WQhkyWiHQX0RGai9obtbOX13R0=",
+      "dev": true
+    },
     "entities": {
       "version": "2.0.3",
       "resolved": "https://registry.npmjs.org/entities/-/entities-2.0.3.tgz",
       "integrity": "sha512-MyoZ0jgnLvB2X3Lg5HqpFmn1kybDiIfEQmKzTb5apr51Rb+T3KdmMiqa70T+bhGnyv7bQ6WMj2QMHpGMmlrUYQ=="
+    },
+    "env-variable": {
+      "version": "0.0.6",
+      "resolved": "https://registry.npmjs.org/env-variable/-/env-variable-0.0.6.tgz",
+      "integrity": "sha1-dKsgs3hsVFtitKSBOrjPInJsmAg=",
+      "dev": true
     },
     "errno": {
       "version": "0.1.7",
@@ -3943,10 +4943,38 @@
       "integrity": "sha512-DR6NO3h9niOT+MZs7bjxlj2a1k+POu5RN8CLTPX2+i78bRi9eLe7+0zXgUHMnGXWybYcL61E9hGhPKqedy8tQA==",
       "dev": true
     },
+    "escape-html": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/escape-html/-/escape-html-1.0.3.tgz",
+      "integrity": "sha1-Aljq5NPQwJdN4cFpGI7wBR0dGYg=",
+      "dev": true
+    },
     "escape-string-regexp": {
       "version": "1.0.5",
       "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz",
       "integrity": "sha1-G2HAViGQqN/2rjuyzwIAyhMLhtQ="
+    },
+    "escodegen": {
+      "version": "1.14.3",
+      "resolved": "https://registry.npmjs.org/escodegen/-/escodegen-1.14.3.tgz",
+      "integrity": "sha1-TnuB+6YVgdyXWC7XjKt/Do1j9QM=",
+      "dev": true,
+      "requires": {
+        "esprima": "^4.0.1",
+        "estraverse": "^4.2.0",
+        "esutils": "^2.0.2",
+        "optionator": "^0.8.1",
+        "source-map": "~0.6.1"
+      },
+      "dependencies": {
+        "source-map": {
+          "version": "0.6.1",
+          "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
+          "integrity": "sha1-dHIq8y6WFOnCh6jQu95IteLxomM=",
+          "dev": true,
+          "optional": true
+        }
+      }
     },
     "eslint-scope": {
       "version": "4.0.3",
@@ -3957,6 +4985,12 @@
         "esrecurse": "^4.1.0",
         "estraverse": "^4.1.1"
       }
+    },
+    "esprima": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/esprima/-/esprima-4.0.1.tgz",
+      "integrity": "sha1-E7BM2z5sXRnfkatph6hpVhmwqnE=",
+      "dev": true
     },
     "esrecurse": {
       "version": "4.2.1",
@@ -3977,6 +5011,12 @@
       "version": "2.0.3",
       "resolved": "https://registry.npmjs.org/esutils/-/esutils-2.0.3.tgz",
       "integrity": "sha512-kVscqXk4OCp68SZ0dkgEKVi6/8ij300KBWTJq32P/dYeWTSwK41WyTxalN1eRmA5Z9UU/LX9D7FWSmV9SAYx6g==",
+      "dev": true
+    },
+    "etag": {
+      "version": "1.8.1",
+      "resolved": "https://registry.npmjs.org/etag/-/etag-1.8.1.tgz",
+      "integrity": "sha1-Qa4u62XvpiJorr/qg6x9eSmbCIc=",
       "dev": true
     },
     "events": {
@@ -4052,6 +5092,118 @@
       "dev": true,
       "requires": {
         "homedir-polyfill": "^1.0.1"
+      }
+    },
+    "expect-ct": {
+      "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/expect-ct/-/expect-ct-0.2.0.tgz",
+      "integrity": "sha1-OlR0G27TTMepMwXGBfY80milSmI=",
+      "dev": true
+    },
+    "express": {
+      "version": "4.17.1",
+      "resolved": "https://registry.npmjs.org/express/-/express-4.17.1.tgz",
+      "integrity": "sha1-RJH8OGBc9R+GKdOcK10Cb5ikwTQ=",
+      "dev": true,
+      "requires": {
+        "accepts": "~1.3.7",
+        "array-flatten": "1.1.1",
+        "body-parser": "1.19.0",
+        "content-disposition": "0.5.3",
+        "content-type": "~1.0.4",
+        "cookie": "0.4.0",
+        "cookie-signature": "1.0.6",
+        "debug": "2.6.9",
+        "depd": "~1.1.2",
+        "encodeurl": "~1.0.2",
+        "escape-html": "~1.0.3",
+        "etag": "~1.8.1",
+        "finalhandler": "~1.1.2",
+        "fresh": "0.5.2",
+        "merge-descriptors": "1.0.1",
+        "methods": "~1.1.2",
+        "on-finished": "~2.3.0",
+        "parseurl": "~1.3.3",
+        "path-to-regexp": "0.1.7",
+        "proxy-addr": "~2.0.5",
+        "qs": "6.7.0",
+        "range-parser": "~1.2.1",
+        "safe-buffer": "5.1.2",
+        "send": "0.17.1",
+        "serve-static": "1.14.1",
+        "setprototypeof": "1.1.1",
+        "statuses": "~1.5.0",
+        "type-is": "~1.6.18",
+        "utils-merge": "1.0.1",
+        "vary": "~1.1.2"
+      },
+      "dependencies": {
+        "debug": {
+          "version": "2.6.9",
+          "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
+          "integrity": "sha1-XRKFFd8TT/Mn6QpMk/Tgd6U2NB8=",
+          "dev": true,
+          "requires": {
+            "ms": "2.0.0"
+          }
+        },
+        "ms": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
+          "integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g=",
+          "dev": true
+        },
+        "qs": {
+          "version": "6.7.0",
+          "resolved": "https://registry.npmjs.org/qs/-/qs-6.7.0.tgz",
+          "integrity": "sha1-QdwaAV49WB8WIXdr4xr7KHapsbw=",
+          "dev": true
+        }
+      }
+    },
+    "express-session": {
+      "version": "1.17.1",
+      "resolved": "https://registry.npmjs.org/express-session/-/express-session-1.17.1.tgz",
+      "integrity": "sha1-Nuy8cDRWbTjIUJiFwETUYcEb81c=",
+      "dev": true,
+      "requires": {
+        "cookie": "0.4.0",
+        "cookie-signature": "1.0.6",
+        "debug": "2.6.9",
+        "depd": "~2.0.0",
+        "on-headers": "~1.0.2",
+        "parseurl": "~1.3.3",
+        "safe-buffer": "5.2.0",
+        "uid-safe": "~2.1.5"
+      },
+      "dependencies": {
+        "debug": {
+          "version": "2.6.9",
+          "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
+          "integrity": "sha1-XRKFFd8TT/Mn6QpMk/Tgd6U2NB8=",
+          "dev": true,
+          "requires": {
+            "ms": "2.0.0"
+          }
+        },
+        "depd": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/depd/-/depd-2.0.0.tgz",
+          "integrity": "sha1-tpYWPMdXVg0JzyLMj60Vcbeedt8=",
+          "dev": true
+        },
+        "ms": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
+          "integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g=",
+          "dev": true
+        },
+        "safe-buffer": {
+          "version": "5.2.0",
+          "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.2.0.tgz",
+          "integrity": "sha1-t02uxJsRSPiMZLaNSbHoFcHy9Rk=",
+          "dev": true
+        }
       }
     },
     "extend": {
@@ -4187,6 +5339,12 @@
       "resolved": "https://registry.npmjs.org/extsprintf/-/extsprintf-1.3.0.tgz",
       "integrity": "sha1-lpGEQOMEGnpBT4xS48V06zw+HgU="
     },
+    "eyes": {
+      "version": "0.1.8",
+      "resolved": "https://registry.npmjs.org/eyes/-/eyes-0.1.8.tgz",
+      "integrity": "sha1-Ys8SAjTGg3hdkCNIqADvPgzCC8A=",
+      "dev": true
+    },
     "fast-deep-equal": {
       "version": "3.1.3",
       "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-3.1.3.tgz",
@@ -4196,6 +5354,30 @@
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/fast-json-stable-stringify/-/fast-json-stable-stringify-2.1.0.tgz",
       "integrity": "sha512-lhd/wF+Lk98HZoTCtlVraHtfh5XYijIjalXck7saUtuanSDyLMxnHhSXEDJqHxD7msR8D0uCmqlkwjCV8xvwHw=="
+    },
+    "fast-levenshtein": {
+      "version": "2.0.6",
+      "resolved": "https://registry.npmjs.org/fast-levenshtein/-/fast-levenshtein-2.0.6.tgz",
+      "integrity": "sha1-PYpcZog6FqMMqGQ+hR8Zuqd5eRc=",
+      "dev": true
+    },
+    "fast-safe-stringify": {
+      "version": "2.0.7",
+      "resolved": "https://registry.npmjs.org/fast-safe-stringify/-/fast-safe-stringify-2.0.7.tgz",
+      "integrity": "sha1-EkqohYmSYfaK7bQqfAgN6dpgh0M=",
+      "dev": true
+    },
+    "feature-policy": {
+      "version": "0.3.0",
+      "resolved": "https://registry.npmjs.org/feature-policy/-/feature-policy-0.3.0.tgz",
+      "integrity": "sha1-dDDo5UpA2gEVbKMKrsGjgc5TYGk=",
+      "dev": true
+    },
+    "fecha": {
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/fecha/-/fecha-4.2.0.tgz",
+      "integrity": "sha1-P/tjlUU+Pz7/+FBATwpZtnR/X0E=",
+      "dev": true
     },
     "figgy-pudding": {
       "version": "3.5.2",
@@ -4240,6 +5422,38 @@
           "requires": {
             "is-extendable": "^0.1.0"
           }
+        }
+      }
+    },
+    "finalhandler": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/finalhandler/-/finalhandler-1.1.2.tgz",
+      "integrity": "sha1-t+fQAP/RGTjQ/bBTUG9uur6fWH0=",
+      "dev": true,
+      "requires": {
+        "debug": "2.6.9",
+        "encodeurl": "~1.0.2",
+        "escape-html": "~1.0.3",
+        "on-finished": "~2.3.0",
+        "parseurl": "~1.3.3",
+        "statuses": "~1.5.0",
+        "unpipe": "~1.0.0"
+      },
+      "dependencies": {
+        "debug": {
+          "version": "2.6.9",
+          "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
+          "integrity": "sha1-XRKFFd8TT/Mn6QpMk/Tgd6U2NB8=",
+          "dev": true,
+          "requires": {
+            "ms": "2.0.0"
+          }
+        },
+        "ms": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
+          "integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g=",
+          "dev": true
         }
       }
     },
@@ -4310,6 +5524,32 @@
         }
       }
     },
+    "follow-redirects": {
+      "version": "1.5.10",
+      "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.5.10.tgz",
+      "integrity": "sha1-e3qfmuov3/NnhqlP9kPtB/T/Xio=",
+      "dev": true,
+      "requires": {
+        "debug": "=3.1.0"
+      },
+      "dependencies": {
+        "debug": {
+          "version": "3.1.0",
+          "resolved": "https://registry.npmjs.org/debug/-/debug-3.1.0.tgz",
+          "integrity": "sha1-W7WgZyYotkFJVmuhaBnmFRjGcmE=",
+          "dev": true,
+          "requires": {
+            "ms": "2.0.0"
+          }
+        },
+        "ms": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
+          "integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g=",
+          "dev": true
+        }
+      }
+    },
     "for-in": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/for-in/-/for-in-1.0.2.tgz",
@@ -4331,6 +5571,12 @@
         "mime-types": "^2.1.12"
       }
     },
+    "forwarded": {
+      "version": "0.1.2",
+      "resolved": "https://registry.npmjs.org/forwarded/-/forwarded-0.1.2.tgz",
+      "integrity": "sha1-mMI9qxF1ZXuMBXPozszZGw/xjIQ=",
+      "dev": true
+    },
     "fragment-cache": {
       "version": "0.2.1",
       "resolved": "https://registry.npmjs.org/fragment-cache/-/fragment-cache-0.2.1.tgz",
@@ -4339,6 +5585,18 @@
       "requires": {
         "map-cache": "^0.2.2"
       }
+    },
+    "frameguard": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/frameguard/-/frameguard-3.1.0.tgz",
+      "integrity": "sha1-vRRCzKHWfcNGpnUVWbbQRQIQOiI=",
+      "dev": true
+    },
+    "fresh": {
+      "version": "0.5.2",
+      "resolved": "https://registry.npmjs.org/fresh/-/fresh-0.5.2.tgz",
+      "integrity": "sha1-PYyt2Q2XZWn6g1qx+OSyOhBWBac=",
+      "dev": true
     },
     "from2": {
       "version": "2.3.0",
@@ -4374,6 +5632,623 @@
             "safe-buffer": "~5.1.0"
           }
         }
+      }
+    },
+    "frontend-analytics": {
+      "version": "2.13.0",
+      "resolved": "http://registry.npm.ml.com/frontend-analytics/-/frontend-analytics-2.13.0.tgz",
+      "integrity": "sha1-VKN1B6z9qKv5UaLCW2EFxweKu/g=",
+      "dev": true,
+      "requires": {
+        "frontend-config": "^1.0.0",
+        "frontend-logger": "^1.0.0",
+        "frontend-restclient": "^2.0.0",
+        "jsesc": "2.5.2",
+        "lodash.merge": "4.6.2"
+      },
+      "dependencies": {
+        "frontend-restclient": {
+          "version": "2.10.0",
+          "resolved": "http://registry.npm.ml.com/frontend-restclient/-/frontend-restclient-2.10.0.tgz",
+          "integrity": "sha1-z2oUCtrboEANzE/70sPqJ39f+cM=",
+          "dev": true,
+          "requires": {
+            "@meli/node-caches": "^2.0.2",
+            "frontend-env": "^2.0.0",
+            "frontend-logger": "^1.0.0",
+            "frontend-statsd": "^1.1.2",
+            "newrelic": "*",
+            "nordic-axios": "2.0.0",
+            "retry": "0.12.0",
+            "stack-trace": "0.0.10",
+            "stale-lru-cache": "5.1.1",
+            "uuid": "3.3.3"
+          }
+        },
+        "is-buffer": {
+          "version": "2.0.4",
+          "resolved": "https://registry.npmjs.org/is-buffer/-/is-buffer-2.0.4.tgz",
+          "integrity": "sha1-PlcvI8hBGlz9lVfISeNmXgspBiM=",
+          "dev": true
+        },
+        "nordic-axios": {
+          "version": "2.0.0",
+          "resolved": "http://registry.npm.ml.com/nordic-axios/-/nordic-axios-2.0.0.tgz",
+          "integrity": "sha1-pAJVjVpjmqZeVqv33w3D0e/fmoM=",
+          "dev": true,
+          "requires": {
+            "follow-redirects": "1.5.10",
+            "is-buffer": "^2.0.2"
+          }
+        },
+        "uuid": {
+          "version": "3.3.3",
+          "resolved": "https://registry.npmjs.org/uuid/-/uuid-3.3.3.tgz",
+          "integrity": "sha1-RWjwIW54dg7h2/Ok0s9T4iQRKGY=",
+          "dev": true
+        }
+      }
+    },
+    "frontend-authentication": {
+      "version": "4.4.0",
+      "resolved": "http://registry.npm.ml.com/frontend-authentication/-/frontend-authentication-4.4.0.tgz",
+      "integrity": "sha1-tCVL/OMKC9jzasIJ7N4sI6fKClA=",
+      "dev": true,
+      "requires": {
+        "frontend-config": "^1.16.9",
+        "frontend-env": "^2.3.0",
+        "frontend-logger": "^1.0.0",
+        "frontend-platform_detection": "^1.2.0",
+        "frontend-restclient": "^2.1.0",
+        "frontend-statsd": "^1.2.0"
+      },
+      "dependencies": {
+        "frontend-restclient": {
+          "version": "2.10.0",
+          "resolved": "http://registry.npm.ml.com/frontend-restclient/-/frontend-restclient-2.10.0.tgz",
+          "integrity": "sha1-z2oUCtrboEANzE/70sPqJ39f+cM=",
+          "dev": true,
+          "requires": {
+            "@meli/node-caches": "^2.0.2",
+            "frontend-env": "^2.0.0",
+            "frontend-logger": "^1.0.0",
+            "frontend-statsd": "^1.1.2",
+            "newrelic": "*",
+            "nordic-axios": "2.0.0",
+            "retry": "0.12.0",
+            "stack-trace": "0.0.10",
+            "stale-lru-cache": "5.1.1",
+            "uuid": "3.3.3"
+          }
+        },
+        "is-buffer": {
+          "version": "2.0.4",
+          "resolved": "https://registry.npmjs.org/is-buffer/-/is-buffer-2.0.4.tgz",
+          "integrity": "sha1-PlcvI8hBGlz9lVfISeNmXgspBiM=",
+          "dev": true
+        },
+        "nordic-axios": {
+          "version": "2.0.0",
+          "resolved": "http://registry.npm.ml.com/nordic-axios/-/nordic-axios-2.0.0.tgz",
+          "integrity": "sha1-pAJVjVpjmqZeVqv33w3D0e/fmoM=",
+          "dev": true,
+          "requires": {
+            "follow-redirects": "1.5.10",
+            "is-buffer": "^2.0.2"
+          }
+        },
+        "uuid": {
+          "version": "3.3.3",
+          "resolved": "https://registry.npmjs.org/uuid/-/uuid-3.3.3.tgz",
+          "integrity": "sha1-RWjwIW54dg7h2/Ok0s9T4iQRKGY=",
+          "dev": true
+        }
+      }
+    },
+    "frontend-cdn-metrics": {
+      "version": "1.0.1",
+      "resolved": "http://registry.npm.ml.com/frontend-cdn-metrics/-/frontend-cdn-metrics-1.0.1.tgz",
+      "integrity": "sha1-8hDQTXU8seUzkgb3mjLRgBAsnA8=",
+      "dev": true
+    },
+    "frontend-config": {
+      "version": "1.34.5",
+      "resolved": "http://registry.npm.ml.com/frontend-config/-/frontend-config-1.34.5.tgz",
+      "integrity": "sha1-IoZmG9L851Kykjs5OcMRpWBt9lM=",
+      "dev": true,
+      "requires": {
+        "frontend-env": "^2.1.0",
+        "frontend-logger": "^1.3.0",
+        "frontend-restclient": "^3.0.0",
+        "frontend-statsd": "^1.2.0",
+        "json5": "2.1.0",
+        "lodash": "4.17.11",
+        "minimist": "1.2.0"
+      },
+      "dependencies": {
+        "json5": {
+          "version": "2.1.0",
+          "resolved": "https://registry.npmjs.org/json5/-/json5-2.1.0.tgz",
+          "integrity": "sha1-56DGLEgoXGKNIKELhcibuAfDKFA=",
+          "dev": true,
+          "requires": {
+            "minimist": "^1.2.0"
+          }
+        },
+        "lodash": {
+          "version": "4.17.11",
+          "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.11.tgz",
+          "integrity": "sha1-s56mIp72B+zYniyN8SU2iRysm40=",
+          "dev": true
+        },
+        "minimist": {
+          "version": "1.2.0",
+          "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz",
+          "integrity": "sha1-o1AIsg9BOD7sH7kU9M1d95omQoQ=",
+          "dev": true
+        }
+      }
+    },
+    "frontend-country_config": {
+      "version": "1.6.0",
+      "resolved": "http://registry.npm.ml.com/frontend-country_config/-/frontend-country_config-1.6.0.tgz",
+      "integrity": "sha1-7idv1/+rT6k8+xlStaequXijA9c=",
+      "dev": true,
+      "requires": {
+        "frontend-env": "^2.0.0",
+        "frontend-logger": "^1.2.1"
+      }
+    },
+    "frontend-device_detection": {
+      "version": "1.11.1",
+      "resolved": "http://registry.npm.ml.com/frontend-device_detection/-/frontend-device_detection-1.11.1.tgz",
+      "integrity": "sha1-T2AP1A6cZ/E1avrxexMM5jMjFfY=",
+      "dev": true,
+      "requires": {
+        "useragent": "2.3.0"
+      }
+    },
+    "frontend-env": {
+      "version": "2.3.0",
+      "resolved": "http://registry.npm.ml.com/frontend-env/-/frontend-env-2.3.0.tgz",
+      "integrity": "sha1-gExc6RAN5eKuUBCoi3pdtmGQ2FE=",
+      "dev": true
+    },
+    "frontend-google-tag-manager": {
+      "version": "1.2.0",
+      "resolved": "http://registry.npm.ml.com/frontend-google-tag-manager/-/frontend-google-tag-manager-1.2.0.tgz",
+      "integrity": "sha1-rmgWP/8VzwY7sw8NvLxNwOawfrU=",
+      "dev": true
+    },
+    "frontend-hotjar": {
+      "version": "1.2.0",
+      "resolved": "http://registry.npm.ml.com/frontend-hotjar/-/frontend-hotjar-1.2.0.tgz",
+      "integrity": "sha1-Rbt6jBWjmA9ExLXPLw34tObwuDw=",
+      "dev": true
+    },
+    "frontend-i18n": {
+      "version": "3.7.0",
+      "resolved": "http://registry.npm.ml.com/frontend-i18n/-/frontend-i18n-3.7.0.tgz",
+      "integrity": "sha1-/1/GsRIgpI7BWqLsHKJ4Ej+Pqtk=",
+      "dev": true,
+      "requires": {
+        "adm-zip": "0.4.13",
+        "commander": "3.0.2",
+        "frontend-config": "^1.1.0",
+        "frontend-country_config": "^1.0.0",
+        "frontend-logger": "^1.0.0",
+        "jsonfile": "5.0.0",
+        "mkdirp": "0.5.1",
+        "po2json": "1.0.0-alpha",
+        "request": "2.88.0"
+      },
+      "dependencies": {
+        "commander": {
+          "version": "3.0.2",
+          "resolved": "https://registry.npmjs.org/commander/-/commander-3.0.2.tgz",
+          "integrity": "sha1-aDfD+2d62ZM9HPukLdFNURfWs54=",
+          "dev": true
+        },
+        "minimist": {
+          "version": "0.0.8",
+          "resolved": "https://registry.npmjs.org/minimist/-/minimist-0.0.8.tgz",
+          "integrity": "sha1-hX/Kv8M5fSYluCKCYuhqp6ARsF0=",
+          "dev": true
+        },
+        "mkdirp": {
+          "version": "0.5.1",
+          "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.1.tgz",
+          "integrity": "sha1-MAV0OOrGz3+MR2fzhkjWaX11yQM=",
+          "dev": true,
+          "requires": {
+            "minimist": "0.0.8"
+          }
+        },
+        "punycode": {
+          "version": "1.4.1",
+          "resolved": "https://registry.npmjs.org/punycode/-/punycode-1.4.1.tgz",
+          "integrity": "sha1-wNWmOycYgArY4esPpSachN1BhF4=",
+          "dev": true
+        },
+        "request": {
+          "version": "2.88.0",
+          "resolved": "https://registry.npmjs.org/request/-/request-2.88.0.tgz",
+          "integrity": "sha1-nC/KT301tZLv5Xx/ClXoEFIST+8=",
+          "dev": true,
+          "requires": {
+            "aws-sign2": "~0.7.0",
+            "aws4": "^1.8.0",
+            "caseless": "~0.12.0",
+            "combined-stream": "~1.0.6",
+            "extend": "~3.0.2",
+            "forever-agent": "~0.6.1",
+            "form-data": "~2.3.2",
+            "har-validator": "~5.1.0",
+            "http-signature": "~1.2.0",
+            "is-typedarray": "~1.0.0",
+            "isstream": "~0.1.2",
+            "json-stringify-safe": "~5.0.1",
+            "mime-types": "~2.1.19",
+            "oauth-sign": "~0.9.0",
+            "performance-now": "^2.1.0",
+            "qs": "~6.5.2",
+            "safe-buffer": "^5.1.2",
+            "tough-cookie": "~2.4.3",
+            "tunnel-agent": "^0.6.0",
+            "uuid": "^3.3.2"
+          }
+        },
+        "tough-cookie": {
+          "version": "2.4.3",
+          "resolved": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-2.4.3.tgz",
+          "integrity": "sha1-U/Nto/R3g7CSWvoG/587FlKA94E=",
+          "dev": true,
+          "requires": {
+            "psl": "^1.1.24",
+            "punycode": "^1.4.1"
+          }
+        }
+      }
+    },
+    "frontend-image": {
+      "version": "1.6.0",
+      "resolved": "http://registry.npm.ml.com/frontend-image/-/frontend-image-1.6.0.tgz",
+      "integrity": "sha1-/Kd3+UaLp7ys8JAldkKeDPsr/Vs=",
+      "dev": true,
+      "requires": {
+        "@frontend-performance/image-lazy-loading": "^1.3.0",
+        "classnames": "2.2.6",
+        "commander": "3.0.2",
+        "ent": "2.2.0",
+        "glob": "7.1.4",
+        "indent-string": "4.0.0",
+        "pretty": "2.0.0",
+        "svg-to-jsx": "1.0.2",
+        "svgo": "1.3.0"
+      },
+      "dependencies": {
+        "commander": {
+          "version": "3.0.2",
+          "resolved": "https://registry.npmjs.org/commander/-/commander-3.0.2.tgz",
+          "integrity": "sha1-aDfD+2d62ZM9HPukLdFNURfWs54=",
+          "dev": true
+        },
+        "glob": {
+          "version": "7.1.4",
+          "resolved": "https://registry.npmjs.org/glob/-/glob-7.1.4.tgz",
+          "integrity": "sha1-qmCKL2xXetNX4a5aXCbZqNGWklU=",
+          "dev": true,
+          "requires": {
+            "fs.realpath": "^1.0.0",
+            "inflight": "^1.0.4",
+            "inherits": "2",
+            "minimatch": "^3.0.4",
+            "once": "^1.3.0",
+            "path-is-absolute": "^1.0.0"
+          }
+        },
+        "indent-string": {
+          "version": "4.0.0",
+          "resolved": "https://registry.npmjs.org/indent-string/-/indent-string-4.0.0.tgz",
+          "integrity": "sha1-Yk+PRJfWGbLZdoUx1Y9BIoVNclE=",
+          "dev": true
+        }
+      }
+    },
+    "frontend-layout": {
+      "version": "3.39.2",
+      "resolved": "http://registry.npm.ml.com/frontend-layout/-/frontend-layout-3.39.2.tgz",
+      "integrity": "sha1-P6940+yejqaKZUf1iBs6pi7VWlw=",
+      "dev": true,
+      "requires": {
+        "@meli/mobile-webkit": "1.21.0",
+        "aphrodite": "2.4.0",
+        "frontend-cdn-metrics": "1.0.1",
+        "frontend-config": "^1.16.0",
+        "frontend-env": "^2.0.0",
+        "frontend-google-tag-manager": "1.2.0",
+        "frontend-hotjar": "1.2.0",
+        "frontend-metrics": "1.2.0",
+        "frontend-navigations": "2.0.2",
+        "html-escaper": "2.0.0",
+        "nav-cart": "1.2.1",
+        "nav-guest-cart": "0.1.0",
+        "nordic-attribution": "1.6.5",
+        "ui-navigation": "5.6.1"
+      }
+    },
+    "frontend-logger": {
+      "version": "1.3.0",
+      "resolved": "http://registry.npm.ml.com/frontend-logger/-/frontend-logger-1.3.0.tgz",
+      "integrity": "sha1-8Cp+43BJ+gDfkuZdJ8zzNsCupaw=",
+      "dev": true,
+      "requires": {
+        "frontend-env": "^2.0.0",
+        "winston": "3.2.1"
+      }
+    },
+    "frontend-melidata": {
+      "version": "3.7.0",
+      "resolved": "http://registry.npm.ml.com/frontend-melidata/-/frontend-melidata-3.7.0.tgz",
+      "integrity": "sha1-MP4yxwYt2QrKUvwenyzPxiMuaZI=",
+      "dev": true,
+      "requires": {
+        "dateformat": "3.0.3",
+        "frontend-config": "^1.0.0",
+        "frontend-env": "^2.2.0",
+        "frontend-logger": "^1.0.0",
+        "frontend-restclient": "^2.0.0",
+        "node-biginteger": "0.0.10",
+        "uuid": "3.3.3",
+        "xss": "1.0.6"
+      },
+      "dependencies": {
+        "frontend-restclient": {
+          "version": "2.10.0",
+          "resolved": "http://registry.npm.ml.com/frontend-restclient/-/frontend-restclient-2.10.0.tgz",
+          "integrity": "sha1-z2oUCtrboEANzE/70sPqJ39f+cM=",
+          "dev": true,
+          "requires": {
+            "@meli/node-caches": "^2.0.2",
+            "frontend-env": "^2.0.0",
+            "frontend-logger": "^1.0.0",
+            "frontend-statsd": "^1.1.2",
+            "newrelic": "*",
+            "nordic-axios": "2.0.0",
+            "retry": "0.12.0",
+            "stack-trace": "0.0.10",
+            "stale-lru-cache": "5.1.1",
+            "uuid": "3.3.3"
+          }
+        },
+        "is-buffer": {
+          "version": "2.0.4",
+          "resolved": "https://registry.npmjs.org/is-buffer/-/is-buffer-2.0.4.tgz",
+          "integrity": "sha1-PlcvI8hBGlz9lVfISeNmXgspBiM=",
+          "dev": true
+        },
+        "nordic-axios": {
+          "version": "2.0.0",
+          "resolved": "http://registry.npm.ml.com/nordic-axios/-/nordic-axios-2.0.0.tgz",
+          "integrity": "sha1-pAJVjVpjmqZeVqv33w3D0e/fmoM=",
+          "dev": true,
+          "requires": {
+            "follow-redirects": "1.5.10",
+            "is-buffer": "^2.0.2"
+          }
+        },
+        "uuid": {
+          "version": "3.3.3",
+          "resolved": "https://registry.npmjs.org/uuid/-/uuid-3.3.3.tgz",
+          "integrity": "sha1-RWjwIW54dg7h2/Ok0s9T4iQRKGY=",
+          "dev": true
+        }
+      }
+    },
+    "frontend-metrics": {
+      "version": "1.2.0",
+      "resolved": "http://registry.npm.ml.com/frontend-metrics/-/frontend-metrics-1.2.0.tgz",
+      "integrity": "sha1-BO4brTYNdVSYzHumhZ96uAVS0ZE=",
+      "dev": true
+    },
+    "frontend-mshops-detection": {
+      "version": "1.1.0",
+      "resolved": "http://registry.npm.ml.com/frontend-mshops-detection/-/frontend-mshops-detection-1.1.0.tgz",
+      "integrity": "sha1-51bJeZadA+wwEONTRIPvfy2V1uE=",
+      "dev": true,
+      "requires": {
+        "frontend-env": "^2.2.0",
+        "frontend-logger": "^1.2.1",
+        "frontend-restclient": "^2.5.0",
+        "mshops-web-utils": "^0.4.0"
+      },
+      "dependencies": {
+        "frontend-restclient": {
+          "version": "2.10.0",
+          "resolved": "http://registry.npm.ml.com/frontend-restclient/-/frontend-restclient-2.10.0.tgz",
+          "integrity": "sha1-z2oUCtrboEANzE/70sPqJ39f+cM=",
+          "dev": true,
+          "requires": {
+            "@meli/node-caches": "^2.0.2",
+            "frontend-env": "^2.0.0",
+            "frontend-logger": "^1.0.0",
+            "frontend-statsd": "^1.1.2",
+            "newrelic": "*",
+            "nordic-axios": "2.0.0",
+            "retry": "0.12.0",
+            "stack-trace": "0.0.10",
+            "stale-lru-cache": "5.1.1",
+            "uuid": "3.3.3"
+          }
+        },
+        "is-buffer": {
+          "version": "2.0.4",
+          "resolved": "https://registry.npmjs.org/is-buffer/-/is-buffer-2.0.4.tgz",
+          "integrity": "sha1-PlcvI8hBGlz9lVfISeNmXgspBiM=",
+          "dev": true
+        },
+        "nordic-axios": {
+          "version": "2.0.0",
+          "resolved": "http://registry.npm.ml.com/nordic-axios/-/nordic-axios-2.0.0.tgz",
+          "integrity": "sha1-pAJVjVpjmqZeVqv33w3D0e/fmoM=",
+          "dev": true,
+          "requires": {
+            "follow-redirects": "1.5.10",
+            "is-buffer": "^2.0.2"
+          }
+        },
+        "uuid": {
+          "version": "3.3.3",
+          "resolved": "https://registry.npmjs.org/uuid/-/uuid-3.3.3.tgz",
+          "integrity": "sha1-RWjwIW54dg7h2/Ok0s9T4iQRKGY=",
+          "dev": true
+        }
+      }
+    },
+    "frontend-navigations": {
+      "version": "2.0.2",
+      "resolved": "http://registry.npm.ml.com/frontend-navigations/-/frontend-navigations-2.0.2.tgz",
+      "integrity": "sha1-bM4BvA+oAFAPc28YEkX86Jxn9F4=",
+      "dev": true,
+      "requires": {
+        "@frontend-navigations/cb": "2.0.0",
+        "@frontend-navigations/classi": "1.0.3",
+        "@frontend-navigations/first-party": "1.0.1",
+        "@frontend-navigations/ml": "1.5.2",
+        "@frontend-navigations/mp": "1.1.1",
+        "@frontend-navigations/ms": "1.0.6",
+        "@frontend-navigations/pi": "1.0.4"
+      }
+    },
+    "frontend-page": {
+      "version": "1.3.0",
+      "resolved": "http://registry.npm.ml.com/frontend-page/-/frontend-page-1.3.0.tgz",
+      "integrity": "sha1-UQPBPn3451BfNnpBHAODoQC6Q2g=",
+      "dev": true
+    },
+    "frontend-platform_detection": {
+      "version": "1.5.0",
+      "resolved": "http://registry.npm.ml.com/frontend-platform_detection/-/frontend-platform_detection-1.5.0.tgz",
+      "integrity": "sha1-eW7IK0Ya8vIjSirCAqdSWNQY9NI=",
+      "dev": true,
+      "requires": {
+        "frontend-logger": "^1.2.1"
+      }
+    },
+    "frontend-prevent-open-redirect": {
+      "version": "1.1.1",
+      "resolved": "http://registry.npm.ml.com/frontend-prevent-open-redirect/-/frontend-prevent-open-redirect-1.1.1.tgz",
+      "integrity": "sha1-FM40LWfJ2v3TfxWcF6l8/wadPR4=",
+      "dev": true,
+      "requires": {
+        "frontend-config": "^1.14.3",
+        "frontend-env": "^2.0.0",
+        "frontend-logger": "^1.0.0",
+        "frontend-platform_detection": "^1.2.2",
+        "frontend-restclient": "^2.1.0",
+        "frontend-statsd": "^1.1.2"
+      },
+      "dependencies": {
+        "frontend-restclient": {
+          "version": "2.10.0",
+          "resolved": "http://registry.npm.ml.com/frontend-restclient/-/frontend-restclient-2.10.0.tgz",
+          "integrity": "sha1-z2oUCtrboEANzE/70sPqJ39f+cM=",
+          "dev": true,
+          "requires": {
+            "@meli/node-caches": "^2.0.2",
+            "frontend-env": "^2.0.0",
+            "frontend-logger": "^1.0.0",
+            "frontend-statsd": "^1.1.2",
+            "newrelic": "*",
+            "nordic-axios": "2.0.0",
+            "retry": "0.12.0",
+            "stack-trace": "0.0.10",
+            "stale-lru-cache": "5.1.1",
+            "uuid": "3.3.3"
+          }
+        },
+        "is-buffer": {
+          "version": "2.0.4",
+          "resolved": "https://registry.npmjs.org/is-buffer/-/is-buffer-2.0.4.tgz",
+          "integrity": "sha1-PlcvI8hBGlz9lVfISeNmXgspBiM=",
+          "dev": true
+        },
+        "nordic-axios": {
+          "version": "2.0.0",
+          "resolved": "http://registry.npm.ml.com/nordic-axios/-/nordic-axios-2.0.0.tgz",
+          "integrity": "sha1-pAJVjVpjmqZeVqv33w3D0e/fmoM=",
+          "dev": true,
+          "requires": {
+            "follow-redirects": "1.5.10",
+            "is-buffer": "^2.0.2"
+          }
+        },
+        "uuid": {
+          "version": "3.3.3",
+          "resolved": "https://registry.npmjs.org/uuid/-/uuid-3.3.3.tgz",
+          "integrity": "sha1-RWjwIW54dg7h2/Ok0s9T4iQRKGY=",
+          "dev": true
+        }
+      }
+    },
+    "frontend-restclient": {
+      "version": "3.0.0",
+      "resolved": "http://registry.npm.ml.com/frontend-restclient/-/frontend-restclient-3.0.0.tgz",
+      "integrity": "sha1-Ybz4bsz4x2lMqY/S8JcxtSlHGOQ=",
+      "dev": true,
+      "requires": {
+        "@meli/node-caches": "^2.0.2",
+        "frontend-env": "^2.0.0",
+        "frontend-logger": "^1.0.0",
+        "frontend-statsd": "^1.1.2",
+        "newrelic": "*",
+        "nordic-axios": "3.0.0",
+        "retry": "0.12.0",
+        "stack-trace": "0.0.10",
+        "stale-lru-cache": "5.1.1",
+        "uuid": "3.3.3"
+      },
+      "dependencies": {
+        "uuid": {
+          "version": "3.3.3",
+          "resolved": "https://registry.npmjs.org/uuid/-/uuid-3.3.3.tgz",
+          "integrity": "sha1-RWjwIW54dg7h2/Ok0s9T4iQRKGY=",
+          "dev": true
+        }
+      }
+    },
+    "frontend-script": {
+      "version": "4.2.1",
+      "resolved": "http://registry.npm.ml.com/frontend-script/-/frontend-script-4.2.1.tgz",
+      "integrity": "sha1-YSznN8mB+avln4z9rm9EkqBYfXA=",
+      "dev": true,
+      "requires": {
+        "frontend-env": "^2.0.0",
+        "frontend-logger": "^1.1.0",
+        "http-link-header": "1.0.2"
+      }
+    },
+    "frontend-statsd": {
+      "version": "1.2.1",
+      "resolved": "http://registry.npm.ml.com/frontend-statsd/-/frontend-statsd-1.2.1.tgz",
+      "integrity": "sha1-CggRzSEL/2u4nYGi9jwxGNXy50g=",
+      "dev": true,
+      "requires": {
+        "frontend-config": "^1.0.0",
+        "frontend-env": "^2.1.0",
+        "frontend-logger": "^1.0.0",
+        "hot-shots": "6.8.1"
+      }
+    },
+    "frontend-style": {
+      "version": "4.3.0",
+      "resolved": "http://registry.npm.ml.com/frontend-style/-/frontend-style-4.3.0.tgz",
+      "integrity": "sha1-ImeFYM6g3N4ahD0OqFqDt/GI4GU=",
+      "dev": true,
+      "requires": {
+        "frontend-env": "^2.0.0",
+        "frontend-logger": "^1.1.0",
+        "http-link-header": "1.0.2"
       }
     },
     "fs-write-stream-atomic": {
@@ -4442,6 +6317,16 @@
       "resolved": "https://registry.npmjs.org/function-bind/-/function-bind-1.1.1.tgz",
       "integrity": "sha512-yIovAzMX49sF8Yl58fSCWJ5svSLuaibPxXQJFLmBObTuCr0Mf1KiPopGM9NiFjiYBCbfaa2Fh6breQ6ANVTI0A==",
       "dev": true
+    },
+    "fury-session": {
+      "version": "1.3.3",
+      "resolved": "http://registry.npm.ml.com/fury-session/-/fury-session-1.3.3.tgz",
+      "integrity": "sha1-DAMBZ92Gcn/lCs7PePP1AfPmzok=",
+      "dev": true,
+      "requires": {
+        "connect-kvs": "^1.4.2",
+        "express-session": "^1.1.0"
+      }
     },
     "gauge": {
       "version": "2.7.4",
@@ -4514,6 +6399,37 @@
       "integrity": "sha1-Xv+OPmhNVprkyysSgmBOi6YhSfo=",
       "requires": {
         "assert-plus": "^1.0.0"
+      }
+    },
+    "gettext-parser": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/gettext-parser/-/gettext-parser-2.0.0.tgz",
+      "integrity": "sha1-wouzHmH3bxRmXfr7tcBRjNwScO0=",
+      "dev": true,
+      "requires": {
+        "encoding": "^0.1.12",
+        "safe-buffer": "^5.1.2"
+      }
+    },
+    "gettext-to-messageformat": {
+      "version": "0.3.1",
+      "resolved": "https://registry.npmjs.org/gettext-to-messageformat/-/gettext-to-messageformat-0.3.1.tgz",
+      "integrity": "sha1-wwP/njGlx4GxRimxO92ye5/8ofg=",
+      "dev": true,
+      "requires": {
+        "gettext-parser": "^1.4.0"
+      },
+      "dependencies": {
+        "gettext-parser": {
+          "version": "1.4.0",
+          "resolved": "https://registry.npmjs.org/gettext-parser/-/gettext-parser-1.4.0.tgz",
+          "integrity": "sha1-+LrzSikvA9XkLwLfCZ0wHxZ6es4=",
+          "dev": true,
+          "requires": {
+            "encoding": "^0.1.12",
+            "safe-buffer": "^5.1.1"
+          }
+        }
       }
     },
     "glob": {
@@ -4703,10 +6619,75 @@
         "minimalistic-assert": "^1.0.1"
       }
     },
+    "hashring": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/hashring/-/hashring-3.2.0.tgz",
+      "integrity": "sha1-/aTv3oqiLNuX+x0qZeiEAeHBRM4=",
+      "dev": true,
+      "requires": {
+        "connection-parse": "0.0.x",
+        "simple-lru-cache": "0.0.x"
+      }
+    },
     "he": {
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/he/-/he-1.2.0.tgz",
       "integrity": "sha512-F/1DnUGPopORZi0ni+CvrCgHQ5FyEAHRLSApuYWMmrbSwoN2Mn/7k+Gl38gJnR7yyDZk6WLXwiGod1JOWNDKGw==",
+      "dev": true
+    },
+    "helmet": {
+      "version": "3.21.1",
+      "resolved": "https://registry.npmjs.org/helmet/-/helmet-3.21.1.tgz",
+      "integrity": "sha1-sKt8Y/ww3yQ0vifn4pKpUjsxR+k=",
+      "dev": true,
+      "requires": {
+        "depd": "2.0.0",
+        "dns-prefetch-control": "0.2.0",
+        "dont-sniff-mimetype": "1.1.0",
+        "expect-ct": "0.2.0",
+        "feature-policy": "0.3.0",
+        "frameguard": "3.1.0",
+        "helmet-crossdomain": "0.4.0",
+        "helmet-csp": "2.9.2",
+        "hide-powered-by": "1.1.0",
+        "hpkp": "2.0.0",
+        "hsts": "2.2.0",
+        "ienoopen": "1.1.0",
+        "nocache": "2.1.0",
+        "referrer-policy": "1.2.0",
+        "x-xss-protection": "1.3.0"
+      },
+      "dependencies": {
+        "depd": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/depd/-/depd-2.0.0.tgz",
+          "integrity": "sha1-tpYWPMdXVg0JzyLMj60Vcbeedt8=",
+          "dev": true
+        }
+      }
+    },
+    "helmet-crossdomain": {
+      "version": "0.4.0",
+      "resolved": "https://registry.npmjs.org/helmet-crossdomain/-/helmet-crossdomain-0.4.0.tgz",
+      "integrity": "sha1-Xx/lqDbQMl8doKeOql/YQpB4iU4=",
+      "dev": true
+    },
+    "helmet-csp": {
+      "version": "2.9.2",
+      "resolved": "https://registry.npmjs.org/helmet-csp/-/helmet-csp-2.9.2.tgz",
+      "integrity": "sha1-vsCtrzcLDy53Jnydi24zs0FZweU=",
+      "dev": true,
+      "requires": {
+        "bowser": "^2.6.1",
+        "camelize": "1.0.0",
+        "content-security-policy-builder": "2.1.0",
+        "dasherize": "2.0.0"
+      }
+    },
+    "hide-powered-by": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/hide-powered-by/-/hide-powered-by-1.1.0.tgz",
+      "integrity": "sha1-vj6pyrS9sW+HRL6HN1XKZjOD+no=",
       "dev": true
     },
     "hmac-drbg": {
@@ -4744,6 +6725,112 @@
       "resolved": "https://registry.npmjs.org/hosted-git-info/-/hosted-git-info-2.8.8.tgz",
       "integrity": "sha512-f/wzC2QaWBs7t9IYqB4T3sR1xviIViXJRJTWBlx2Gf3g0Xi5vI7Yy4koXQ1c9OYDGHN9sBy1DQ2AB8fqZBWhUg=="
     },
+    "hot-shots": {
+      "version": "6.8.1",
+      "resolved": "https://registry.npmjs.org/hot-shots/-/hot-shots-6.8.1.tgz",
+      "integrity": "sha1-KBbpsz1iXK/YxzK/Miop69NtAk4=",
+      "dev": true,
+      "requires": {
+        "unix-dgram": "2.0.x"
+      }
+    },
+    "hpkp": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/hpkp/-/hpkp-2.0.0.tgz",
+      "integrity": "sha1-EOFCJk52IVpdMMROxD3mTe5tFnI=",
+      "dev": true
+    },
+    "hpp": {
+      "version": "0.2.2",
+      "resolved": "https://registry.npmjs.org/hpp/-/hpp-0.2.2.tgz",
+      "integrity": "sha1-DsX3dHIEmnQ2HYW6K4jiRwpDVvg=",
+      "dev": true,
+      "requires": {
+        "lodash": "^4.7.0",
+        "type-is": "^1.6.12"
+      }
+    },
+    "hsts": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/hsts/-/hsts-2.2.0.tgz",
+      "integrity": "sha1-CRGdQveoWHA10CfdpFIjZv512WQ=",
+      "dev": true,
+      "requires": {
+        "depd": "2.0.0"
+      },
+      "dependencies": {
+        "depd": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/depd/-/depd-2.0.0.tgz",
+          "integrity": "sha1-tpYWPMdXVg0JzyLMj60Vcbeedt8=",
+          "dev": true
+        }
+      }
+    },
+    "html-dom-parser": {
+      "version": "0.2.3",
+      "resolved": "https://registry.npmjs.org/html-dom-parser/-/html-dom-parser-0.2.3.tgz",
+      "integrity": "sha1-v+5ZL8AcErrAjc+l2iYR+VWaGBI=",
+      "dev": true,
+      "requires": {
+        "@types/domhandler": "2.4.1",
+        "domhandler": "2.4.2",
+        "htmlparser2": "3.10.1"
+      },
+      "dependencies": {
+        "domelementtype": {
+          "version": "1.3.1",
+          "resolved": "https://registry.npmjs.org/domelementtype/-/domelementtype-1.3.1.tgz",
+          "integrity": "sha1-0EjESzew0Qp/Kj1f7j9DM9eQSB8=",
+          "dev": true
+        },
+        "domhandler": {
+          "version": "2.4.2",
+          "resolved": "https://registry.npmjs.org/domhandler/-/domhandler-2.4.2.tgz",
+          "integrity": "sha1-iAUJfpM9ZehVRvcm1g9euItE+AM=",
+          "dev": true,
+          "requires": {
+            "domelementtype": "1"
+          }
+        },
+        "domutils": {
+          "version": "1.7.0",
+          "resolved": "https://registry.npmjs.org/domutils/-/domutils-1.7.0.tgz",
+          "integrity": "sha1-Vuo0HoNOBuZ0ivehyyXaZ+qfjCo=",
+          "dev": true,
+          "requires": {
+            "dom-serializer": "0",
+            "domelementtype": "1"
+          }
+        },
+        "entities": {
+          "version": "1.1.2",
+          "resolved": "https://registry.npmjs.org/entities/-/entities-1.1.2.tgz",
+          "integrity": "sha1-vfpzUplmTfr9NFKe1PhSKidf6lY=",
+          "dev": true
+        },
+        "htmlparser2": {
+          "version": "3.10.1",
+          "resolved": "https://registry.npmjs.org/htmlparser2/-/htmlparser2-3.10.1.tgz",
+          "integrity": "sha1-vWedw/WYl7ajS7EHSchVu1OpOS8=",
+          "dev": true,
+          "requires": {
+            "domelementtype": "^1.3.1",
+            "domhandler": "^2.3.0",
+            "domutils": "^1.5.1",
+            "entities": "^1.1.1",
+            "inherits": "^2.0.1",
+            "readable-stream": "^3.1.1"
+          }
+        }
+      }
+    },
+    "html-escaper": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/html-escaper/-/html-escaper-2.0.0.tgz",
+      "integrity": "sha1-ceh/kx3j/gnlZmGrmimq3scHtJE=",
+      "dev": true
+    },
     "html-loader": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/html-loader/-/html-loader-1.1.0.tgz",
@@ -4770,6 +6857,18 @@
         "param-case": "^3.0.3",
         "relateurl": "^0.2.7",
         "terser": "^4.6.3"
+      }
+    },
+    "html-react-parser": {
+      "version": "0.10.1",
+      "resolved": "https://registry.npmjs.org/html-react-parser/-/html-react-parser-0.10.1.tgz",
+      "integrity": "sha1-GoPGNfI0ZF7kiyn42uMdVUWeMEM=",
+      "dev": true,
+      "requires": {
+        "@types/domhandler": "2.4.1",
+        "html-dom-parser": "0.2.3",
+        "react-property": "1.0.1",
+        "style-to-object": "0.3.0"
       }
     },
     "html-webpack-inline-style-plugin": {
@@ -4887,6 +6986,25 @@
         "entities": "^2.0.0"
       }
     },
+    "http-errors": {
+      "version": "1.7.3",
+      "resolved": "https://registry.npmjs.org/http-errors/-/http-errors-1.7.3.tgz",
+      "integrity": "sha1-bGGeT5xgMIw4UZSYwU+7EKrOuwY=",
+      "dev": true,
+      "requires": {
+        "depd": "~1.1.2",
+        "inherits": "2.0.4",
+        "setprototypeof": "1.1.1",
+        "statuses": ">= 1.5.0 < 2",
+        "toidentifier": "1.0.0"
+      }
+    },
+    "http-link-header": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/http-link-header/-/http-link-header-1.0.2.tgz",
+      "integrity": "sha1-vqUPAuHHmWAh8QE7Qoxj934PThE=",
+      "dev": true
+    },
     "http-signature": {
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/http-signature/-/http-signature-1.2.0.tgz",
@@ -4897,11 +7015,42 @@
         "sshpk": "^1.7.0"
       }
     },
+    "http-status-codes": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/http-status-codes/-/http-status-codes-1.4.0.tgz",
+      "integrity": "sha1-bkwV0W/zqeLfA7ifOlXhquBftHc=",
+      "dev": true
+    },
     "https-browserify": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/https-browserify/-/https-browserify-1.0.0.tgz",
       "integrity": "sha1-7AbBDgo0wPL68Zn3/X/Hj//QPHM=",
       "dev": true
+    },
+    "https-proxy-agent": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/https-proxy-agent/-/https-proxy-agent-4.0.0.tgz",
+      "integrity": "sha1-cCtx+1UgoTKmbeH2dUHZ5iFU2Cs=",
+      "dev": true,
+      "requires": {
+        "agent-base": "5",
+        "debug": "4"
+      }
+    },
+    "hyphenate-style-name": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/hyphenate-style-name/-/hyphenate-style-name-1.0.3.tgz",
+      "integrity": "sha1-CXu3+guPGpzwvVxzTPlYmZgam0g=",
+      "dev": true
+    },
+    "iconv-lite": {
+      "version": "0.4.24",
+      "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.4.24.tgz",
+      "integrity": "sha1-ICK0sl+93CHS9SSXSkdKr+czkIs=",
+      "dev": true,
+      "requires": {
+        "safer-buffer": ">= 2.1.2 < 3"
+      }
     },
     "icss-utils": {
       "version": "4.1.1",
@@ -4916,6 +7065,12 @@
       "version": "1.1.13",
       "resolved": "https://registry.npmjs.org/ieee754/-/ieee754-1.1.13.tgz",
       "integrity": "sha512-4vf7I2LYV/HaWerSo3XmlMkp5eZ83i+/CDluXi/IGTs/O1sejBNhTtnxzmRZfvOUqj7lZjqHkeTvpgSFDlWZTg==",
+      "dev": true
+    },
+    "ienoopen": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/ienoopen/-/ienoopen-1.1.0.tgz",
+      "integrity": "sha1-QR5dUwyYIofb3DuzHnqcnjJjCXQ=",
       "dev": true
     },
     "iferr": {
@@ -4990,6 +7145,21 @@
       "integrity": "sha512-RZY5huIKCMRWDUqZlEi72f/lmXKMvuszcMBduliQ3nnWbx9X/ZBQO7DijMEYS9EhHBb2qacRUMtC7svLwe0lcw==",
       "dev": true
     },
+    "inline-style-parser": {
+      "version": "0.1.1",
+      "resolved": "https://registry.npmjs.org/inline-style-parser/-/inline-style-parser-0.1.1.tgz",
+      "integrity": "sha1-7Io7QpJ06cCh8cT/qUU6f+9yzqE=",
+      "dev": true
+    },
+    "inline-style-prefixer": {
+      "version": "5.1.2",
+      "resolved": "https://registry.npmjs.org/inline-style-prefixer/-/inline-style-prefixer-5.1.2.tgz",
+      "integrity": "sha1-5aWjUV4lYA4Ba3HjkTiXEihIbDM=",
+      "dev": true,
+      "requires": {
+        "css-in-js-utils": "^2.0.0"
+      }
+    },
     "interpret": {
       "version": "1.4.0",
       "resolved": "https://registry.npmjs.org/interpret/-/interpret-1.4.0.tgz",
@@ -5004,6 +7174,18 @@
       "requires": {
         "loose-envify": "^1.0.0"
       }
+    },
+    "invert-kv": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/invert-kv/-/invert-kv-1.0.0.tgz",
+      "integrity": "sha1-EEqOSqym09jNFXqO+L+rLXo//bY=",
+      "dev": true
+    },
+    "ipaddr.js": {
+      "version": "1.9.1",
+      "resolved": "https://registry.npmjs.org/ipaddr.js/-/ipaddr.js-1.9.1.tgz",
+      "integrity": "sha1-v/OFQ+64mEglB5/zoqjmy9RngbM=",
+      "dev": true
     },
     "is-accessor-descriptor": {
       "version": "0.1.6",
@@ -5166,6 +7348,12 @@
         "has-symbols": "^1.0.1"
       }
     },
+    "is-stream": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/is-stream/-/is-stream-1.1.0.tgz",
+      "integrity": "sha1-EtSj3U5o4Lec6428hBc66A2RykQ=",
+      "dev": true
+    },
     "is-symbol": {
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/is-symbol/-/is-symbol-1.0.3.tgz",
@@ -5184,6 +7372,12 @@
       "version": "0.2.1",
       "resolved": "https://registry.npmjs.org/is-utf8/-/is-utf8-0.2.1.tgz",
       "integrity": "sha1-Sw2hRCEE0bM2NA6AeX6GXPOffXI="
+    },
+    "is-whitespace": {
+      "version": "0.3.0",
+      "resolved": "https://registry.npmjs.org/is-whitespace/-/is-whitespace-0.3.0.tgz",
+      "integrity": "sha1-Fjnssb4DauxppUy7QBz77XEUq38=",
+      "dev": true
     },
     "is-windows": {
       "version": "1.0.2",
@@ -5218,15 +7412,73 @@
       "resolved": "https://registry.npmjs.org/isstream/-/isstream-0.1.2.tgz",
       "integrity": "sha1-R+Y/evVa+m+S4VAOaQ64uFKcCZo="
     },
+    "jackpot": {
+      "version": "0.0.6",
+      "resolved": "https://registry.npmjs.org/jackpot/-/jackpot-0.0.6.tgz",
+      "integrity": "sha1-PP8GQoXL9m9OqyWTyQvOgWqCGEk=",
+      "dev": true,
+      "requires": {
+        "retry": "0.6.0"
+      },
+      "dependencies": {
+        "retry": {
+          "version": "0.6.0",
+          "resolved": "https://registry.npmjs.org/retry/-/retry-0.6.0.tgz",
+          "integrity": "sha1-HAEHEyeab9Ho3vKK8MP/GHHKpTc=",
+          "dev": true
+        }
+      }
+    },
     "js-base64": {
       "version": "2.6.2",
       "resolved": "https://registry.npmjs.org/js-base64/-/js-base64-2.6.2.tgz",
       "integrity": "sha512-1hgLrLIrmCgZG+ID3VoLNLOSwjGnoZa8tyrUdEteMeIzsT6PH7PMLyUvbDwzNE56P3PNxyvuIOx4Uh2E5rzQIw=="
     },
+    "js-beautify": {
+      "version": "1.11.0",
+      "resolved": "https://registry.npmjs.org/js-beautify/-/js-beautify-1.11.0.tgz",
+      "integrity": "sha1-r7hz3EfViYY2AJPctplR6LzV3tI=",
+      "dev": true,
+      "requires": {
+        "config-chain": "^1.1.12",
+        "editorconfig": "^0.15.3",
+        "glob": "^7.1.3",
+        "mkdirp": "~1.0.3",
+        "nopt": "^4.0.3"
+      },
+      "dependencies": {
+        "mkdirp": {
+          "version": "1.0.4",
+          "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-1.0.4.tgz",
+          "integrity": "sha1-PrXtYmInVteaXw4qIh3+utdcL34=",
+          "dev": true
+        },
+        "nopt": {
+          "version": "4.0.3",
+          "resolved": "https://registry.npmjs.org/nopt/-/nopt-4.0.3.tgz",
+          "integrity": "sha1-o3XK2dAv2SEnjZVMIlTVqlfhXkg=",
+          "dev": true,
+          "requires": {
+            "abbrev": "1",
+            "osenv": "^0.1.4"
+          }
+        }
+      }
+    },
     "js-tokens": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-4.0.0.tgz",
       "integrity": "sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ=="
+    },
+    "js-yaml": {
+      "version": "3.14.0",
+      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.14.0.tgz",
+      "integrity": "sha1-p6NBcPJqIbsWJCTYray0ETpp5II=",
+      "dev": true,
+      "requires": {
+        "argparse": "^1.0.7",
+        "esprima": "^4.0.0"
+      }
     },
     "jsbn": {
       "version": "0.1.1",
@@ -5269,6 +7521,16 @@
         "minimist": "^1.2.5"
       }
     },
+    "jsonfile": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/jsonfile/-/jsonfile-5.0.0.tgz",
+      "integrity": "sha1-5rcY9z2kINYSgjmW/fFKA/b/aSI=",
+      "dev": true,
+      "requires": {
+        "graceful-fs": "^4.1.6",
+        "universalify": "^0.1.2"
+      }
+    },
     "jsprim": {
       "version": "1.4.1",
       "resolved": "https://registry.npmjs.org/jsprim/-/jsprim-1.4.1.tgz",
@@ -5307,6 +7569,126 @@
       "integrity": "sha512-dcS1ul+9tmeD95T+x28/ehLgd9mENa3LsvDTtzm3vyBEO7RPptvAD+t44WVXaUjTBRcrpFeFlC8WCruUR456hw==",
       "dev": true
     },
+    "kuler": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/kuler/-/kuler-1.0.1.tgz",
+      "integrity": "sha1-73x4TzbJ+24W3TFQ0VJneysCKKY=",
+      "dev": true,
+      "requires": {
+        "colornames": "^1.1.1"
+      }
+    },
+    "kvsclient": {
+      "version": "1.3.0",
+      "resolved": "http://registry.npm.ml.com/kvsclient/-/kvsclient-1.3.0.tgz",
+      "integrity": "sha1-Tmf3D13k8xqa8p7+Q+WtPp0ZvOU=",
+      "dev": true,
+      "requires": {
+        "frontend-env": "^2.0.0",
+        "frontend-restclient": "^2.0.1",
+        "hot-shots": "^6.1.1",
+        "http-status-codes": "^1.0.6",
+        "lodash": "^4.13.1",
+        "query-string": "^6.2.0",
+        "winston": "^2.4.4"
+      },
+      "dependencies": {
+        "async": {
+          "version": "1.0.0",
+          "resolved": "https://registry.npmjs.org/async/-/async-1.0.0.tgz",
+          "integrity": "sha1-+PwEyjoTeErenhZBr5hXjPvWR6k=",
+          "dev": true
+        },
+        "colors": {
+          "version": "1.0.3",
+          "resolved": "https://registry.npmjs.org/colors/-/colors-1.0.3.tgz",
+          "integrity": "sha1-BDP0TYCWgP3rYO0mDxsMJi6CpAs=",
+          "dev": true
+        },
+        "frontend-restclient": {
+          "version": "2.10.0",
+          "resolved": "http://registry.npm.ml.com/frontend-restclient/-/frontend-restclient-2.10.0.tgz",
+          "integrity": "sha1-z2oUCtrboEANzE/70sPqJ39f+cM=",
+          "dev": true,
+          "requires": {
+            "@meli/node-caches": "^2.0.2",
+            "frontend-env": "^2.0.0",
+            "frontend-logger": "^1.0.0",
+            "frontend-statsd": "^1.1.2",
+            "newrelic": "*",
+            "nordic-axios": "2.0.0",
+            "retry": "0.12.0",
+            "stack-trace": "0.0.10",
+            "stale-lru-cache": "5.1.1",
+            "uuid": "3.3.3"
+          }
+        },
+        "is-buffer": {
+          "version": "2.0.4",
+          "resolved": "https://registry.npmjs.org/is-buffer/-/is-buffer-2.0.4.tgz",
+          "integrity": "sha1-PlcvI8hBGlz9lVfISeNmXgspBiM=",
+          "dev": true
+        },
+        "nordic-axios": {
+          "version": "2.0.0",
+          "resolved": "http://registry.npm.ml.com/nordic-axios/-/nordic-axios-2.0.0.tgz",
+          "integrity": "sha1-pAJVjVpjmqZeVqv33w3D0e/fmoM=",
+          "dev": true,
+          "requires": {
+            "follow-redirects": "1.5.10",
+            "is-buffer": "^2.0.2"
+          }
+        },
+        "uuid": {
+          "version": "3.3.3",
+          "resolved": "https://registry.npmjs.org/uuid/-/uuid-3.3.3.tgz",
+          "integrity": "sha1-RWjwIW54dg7h2/Ok0s9T4iQRKGY=",
+          "dev": true
+        },
+        "winston": {
+          "version": "2.4.5",
+          "resolved": "https://registry.npmjs.org/winston/-/winston-2.4.5.tgz",
+          "integrity": "sha1-8uQx1WFUxOp2VUX8EAO9NAyVtZo=",
+          "dev": true,
+          "requires": {
+            "async": "~1.0.0",
+            "colors": "1.0.x",
+            "cycle": "1.0.x",
+            "eyes": "0.1.x",
+            "isstream": "0.1.x",
+            "stack-trace": "0.0.x"
+          }
+        }
+      }
+    },
+    "launch-editor": {
+      "version": "2.2.1",
+      "resolved": "https://registry.npmjs.org/launch-editor/-/launch-editor-2.2.1.tgz",
+      "integrity": "sha1-hxtaPuOdZoD8wm03kwtu7aidsMo=",
+      "dev": true,
+      "requires": {
+        "chalk": "^2.3.0",
+        "shell-quote": "^1.6.1"
+      }
+    },
+    "launch-editor-middleware": {
+      "version": "2.2.1",
+      "resolved": "https://registry.npmjs.org/launch-editor-middleware/-/launch-editor-middleware-2.2.1.tgz",
+      "integrity": "sha1-4UsH5scVSwpLhqD9NFeE5FgEwVc=",
+      "dev": true,
+      "requires": {
+        "launch-editor": "^2.2.1"
+      }
+    },
+    "lcid": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/lcid/-/lcid-1.0.0.tgz",
+      "integrity": "sha1-MIrMr6C8SDo4Z7S28rlQYlHRuDU=",
+      "dev": true,
+      "requires": {
+        "invert-kv": "^1.0.0"
+      }
+    },
     "leven": {
       "version": "3.1.0",
       "resolved": "https://registry.npmjs.org/leven/-/leven-3.1.0.tgz",
@@ -5320,6 +7702,16 @@
       "dev": true,
       "requires": {
         "leven": "^3.1.0"
+      }
+    },
+    "levn": {
+      "version": "0.3.0",
+      "resolved": "https://registry.npmjs.org/levn/-/levn-0.3.0.tgz",
+      "integrity": "sha1-OwmSTt+fCDwEkP3UwLxEIeBHZO4=",
+      "dev": true,
+      "requires": {
+        "prelude-ls": "~1.1.2",
+        "type-check": "~0.3.2"
       }
     },
     "load-json-file": {
@@ -5372,6 +7764,12 @@
       "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.15.tgz",
       "integrity": "sha512-8xOcRHvCjnocdS5cpwXQXVzmmh5e5+saE2QGoeQmbKmRS6J3VQppPOIt0MnmE+4xlZoumy0GPG0D0MVIQbNA1A=="
     },
+    "lodash._getnative": {
+      "version": "3.9.1",
+      "resolved": "https://registry.npmjs.org/lodash._getnative/-/lodash._getnative-3.9.1.tgz",
+      "integrity": "sha1-VwvH3t5G1hzc3mh9ZdPuy6o6r/U=",
+      "dev": true
+    },
     "lodash.assignin": {
       "version": "4.2.0",
       "resolved": "https://registry.npmjs.org/lodash.assignin/-/lodash.assignin-4.2.0.tgz",
@@ -5381,6 +7779,12 @@
       "version": "4.2.1",
       "resolved": "https://registry.npmjs.org/lodash.bind/-/lodash.bind-4.2.1.tgz",
       "integrity": "sha1-euMBfpOWIqwxt9fX3LGzTbFpDTU="
+    },
+    "lodash.camelcase": {
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/lodash.camelcase/-/lodash.camelcase-4.3.0.tgz",
+      "integrity": "sha1-soqmKIorn8ZRA1x3EfZathkDMaY=",
+      "dev": true
     },
     "lodash.defaults": {
       "version": "4.2.0",
@@ -5401,6 +7805,29 @@
       "version": "4.5.0",
       "resolved": "https://registry.npmjs.org/lodash.foreach/-/lodash.foreach-4.5.0.tgz",
       "integrity": "sha1-Gmo16s5AEoDH8G3d7DUWWrJ+PlM="
+    },
+    "lodash.isarguments": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/lodash.isarguments/-/lodash.isarguments-3.1.0.tgz",
+      "integrity": "sha1-L1c9hcaiQon/AGY7SRwdM4/zRYo=",
+      "dev": true
+    },
+    "lodash.isarray": {
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/lodash.isarray/-/lodash.isarray-3.0.4.tgz",
+      "integrity": "sha1-eeTriMNqgSKvhvhEqpvNhRtfu1U=",
+      "dev": true
+    },
+    "lodash.keys": {
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/lodash.keys/-/lodash.keys-3.1.2.tgz",
+      "integrity": "sha1-TbwEcrFWvlCgsoaFXRvQsMZWCYo=",
+      "dev": true,
+      "requires": {
+        "lodash._getnative": "^3.0.0",
+        "lodash.isarguments": "^3.0.0",
+        "lodash.isarray": "^3.0.0"
+      }
     },
     "lodash.map": {
       "version": "4.6.0",
@@ -5436,6 +7863,25 @@
       "version": "4.0.1",
       "resolved": "https://registry.npmjs.org/lodash.unescape/-/lodash.unescape-4.0.1.tgz",
       "integrity": "sha1-vyJJiGzlFM2hEvrpIYzcBlIR/Jw="
+    },
+    "logform": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/logform/-/logform-2.2.0.tgz",
+      "integrity": "sha1-QPA20ZFh/Ha2irUP3H/klVREkvI=",
+      "dev": true,
+      "requires": {
+        "colors": "^1.2.1",
+        "fast-safe-stringify": "^2.0.4",
+        "fecha": "^4.2.0",
+        "ms": "^2.1.1",
+        "triple-beam": "^1.3.0"
+      }
+    },
+    "long": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/long/-/long-4.0.0.tgz",
+      "integrity": "sha1-mntxz7fTYaGU6lVSQckvdGjVvyg=",
+      "dev": true
     },
     "loose-envify": {
       "version": "1.4.0",
@@ -5513,6 +7959,28 @@
         "safe-buffer": "^5.1.2"
       }
     },
+    "mdn-data": {
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/mdn-data/-/mdn-data-2.0.4.tgz",
+      "integrity": "sha1-aZs8OKxvHXKAkaZGULZdOIUC/Vs=",
+      "dev": true
+    },
+    "media-typer": {
+      "version": "0.3.0",
+      "resolved": "https://registry.npmjs.org/media-typer/-/media-typer-0.3.0.tgz",
+      "integrity": "sha1-hxDXrwqmJvj/+hzgAWhUUmMlV0g=",
+      "dev": true
+    },
+    "memcached": {
+      "version": "2.2.2",
+      "resolved": "https://registry.npmjs.org/memcached/-/memcached-2.2.2.tgz",
+      "integrity": "sha1-aPhsz9hLz5PMJe1G1tf8DHUhydU=",
+      "dev": true,
+      "requires": {
+        "hashring": "3.2.x",
+        "jackpot": ">=0.0.6"
+      }
+    },
     "memory-fs": {
       "version": "0.4.1",
       "resolved": "https://registry.npmjs.org/memory-fs/-/memory-fs-0.4.1.tgz",
@@ -5571,6 +8039,18 @@
         "trim-newlines": "^1.0.0"
       }
     },
+    "merge-descriptors": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/merge-descriptors/-/merge-descriptors-1.0.1.tgz",
+      "integrity": "sha1-sAqqVW3YtEVoFQ7J0blT8/kMu2E=",
+      "dev": true
+    },
+    "methods": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/methods/-/methods-1.1.2.tgz",
+      "integrity": "sha1-VSmk1nZUE07cxSZmVoNbD4Ua/O4=",
+      "dev": true
+    },
     "micromatch": {
       "version": "3.1.10",
       "resolved": "https://registry.npmjs.org/micromatch/-/micromatch-3.1.10.tgz",
@@ -5609,6 +8089,12 @@
           "dev": true
         }
       }
+    },
+    "mime": {
+      "version": "1.6.0",
+      "resolved": "https://registry.npmjs.org/mime/-/mime-1.6.0.tgz",
+      "integrity": "sha1-Ms2eXGRVO9WNGaVor0Uqz/BJgbE=",
+      "dev": true
     },
     "mime-db": {
       "version": "1.44.0",
@@ -5700,6 +8186,36 @@
         "minimist": "^1.2.5"
       }
     },
+    "morgan": {
+      "version": "1.9.1",
+      "resolved": "https://registry.npmjs.org/morgan/-/morgan-1.9.1.tgz",
+      "integrity": "sha1-Co0Wc0odmvvIJLmd+H5zjlji2lk=",
+      "dev": true,
+      "requires": {
+        "basic-auth": "~2.0.0",
+        "debug": "2.6.9",
+        "depd": "~1.1.2",
+        "on-finished": "~2.3.0",
+        "on-headers": "~1.0.1"
+      },
+      "dependencies": {
+        "debug": {
+          "version": "2.6.9",
+          "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
+          "integrity": "sha1-XRKFFd8TT/Mn6QpMk/Tgd6U2NB8=",
+          "dev": true,
+          "requires": {
+            "ms": "2.0.0"
+          }
+        },
+        "ms": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
+          "integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g=",
+          "dev": true
+        }
+      }
+    },
     "move-concurrently": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/move-concurrently/-/move-concurrently-1.0.1.tgz",
@@ -5718,6 +8234,64 @@
       "version": "2.1.2",
       "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
       "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w==",
+      "dev": true
+    },
+    "mshops-web-utils": {
+      "version": "0.4.0",
+      "resolved": "http://registry.npm.ml.com/mshops-web-utils/-/mshops-web-utils-0.4.0.tgz",
+      "integrity": "sha1-FSl20pj9F1dbAKSS1Oo1oEixsZI=",
+      "dev": true,
+      "requires": {
+        "frontend-logger": "^1.2.1",
+        "frontend-restclient": "^2.5.2"
+      },
+      "dependencies": {
+        "frontend-restclient": {
+          "version": "2.10.0",
+          "resolved": "http://registry.npm.ml.com/frontend-restclient/-/frontend-restclient-2.10.0.tgz",
+          "integrity": "sha1-z2oUCtrboEANzE/70sPqJ39f+cM=",
+          "dev": true,
+          "requires": {
+            "@meli/node-caches": "^2.0.2",
+            "frontend-env": "^2.0.0",
+            "frontend-logger": "^1.0.0",
+            "frontend-statsd": "^1.1.2",
+            "newrelic": "*",
+            "nordic-axios": "2.0.0",
+            "retry": "0.12.0",
+            "stack-trace": "0.0.10",
+            "stale-lru-cache": "5.1.1",
+            "uuid": "3.3.3"
+          }
+        },
+        "is-buffer": {
+          "version": "2.0.4",
+          "resolved": "https://registry.npmjs.org/is-buffer/-/is-buffer-2.0.4.tgz",
+          "integrity": "sha1-PlcvI8hBGlz9lVfISeNmXgspBiM=",
+          "dev": true
+        },
+        "nordic-axios": {
+          "version": "2.0.0",
+          "resolved": "http://registry.npm.ml.com/nordic-axios/-/nordic-axios-2.0.0.tgz",
+          "integrity": "sha1-pAJVjVpjmqZeVqv33w3D0e/fmoM=",
+          "dev": true,
+          "requires": {
+            "follow-redirects": "1.5.10",
+            "is-buffer": "^2.0.2"
+          }
+        },
+        "uuid": {
+          "version": "3.3.3",
+          "resolved": "https://registry.npmjs.org/uuid/-/uuid-3.3.3.tgz",
+          "integrity": "sha1-RWjwIW54dg7h2/Ok0s9T4iQRKGY=",
+          "dev": true
+        }
+      }
+    },
+    "mustache": {
+      "version": "3.2.1",
+      "resolved": "https://registry.npmjs.org/mustache/-/mustache-3.2.1.tgz",
+      "integrity": "sha1-ieeKnSB9ePJ5mx6Vdkolv3GigyI=",
       "dev": true
     },
     "nan": {
@@ -5744,11 +8318,99 @@
         "to-regex": "^3.0.1"
       }
     },
+    "nav-cart": {
+      "version": "1.2.1",
+      "resolved": "http://registry.npm.ml.com/nav-cart/-/nav-cart-1.2.1.tgz",
+      "integrity": "sha1-YioQX1aiB/mycivM2J6maburdWI=",
+      "dev": true,
+      "requires": {
+        "html-escaper": "^1.0.1",
+        "tiny.js": "0.2.4"
+      },
+      "dependencies": {
+        "html-escaper": {
+          "version": "1.0.1",
+          "resolved": "https://registry.npmjs.org/html-escaper/-/html-escaper-1.0.1.tgz",
+          "integrity": "sha1-7gKeKGJnQBeUE1Wn9h/Cx8Cm/XI=",
+          "dev": true
+        }
+      }
+    },
+    "nav-guest-cart": {
+      "version": "0.1.0",
+      "resolved": "http://registry.npm.ml.com/nav-guest-cart/-/nav-guest-cart-0.1.0.tgz",
+      "integrity": "sha1-TBYjSGHagQCHwiX4gAsNS7FCb9Y=",
+      "dev": true,
+      "requires": {
+        "html-escaper": "^1.0.1",
+        "tiny.js": "0.2.4"
+      },
+      "dependencies": {
+        "html-escaper": {
+          "version": "1.0.1",
+          "resolved": "https://registry.npmjs.org/html-escaper/-/html-escaper-1.0.1.tgz",
+          "integrity": "sha1-7gKeKGJnQBeUE1Wn9h/Cx8Cm/XI=",
+          "dev": true
+        }
+      }
+    },
+    "negotiator": {
+      "version": "0.6.2",
+      "resolved": "https://registry.npmjs.org/negotiator/-/negotiator-0.6.2.tgz",
+      "integrity": "sha1-/qz3zPUlp3rpY0Q2pkiD/+yjRvs=",
+      "dev": true
+    },
     "neo-async": {
       "version": "2.6.1",
       "resolved": "https://registry.npmjs.org/neo-async/-/neo-async-2.6.1.tgz",
       "integrity": "sha512-iyam8fBuCUpWeKPGpaNMetEocMt364qkCsfL9JuhjXX6dRnguRVOfk2GZaDpPjcOKiiXCPINZC1GczQ7iTq3Zw==",
       "dev": true
+    },
+    "newrelic": {
+      "version": "6.7.1",
+      "resolved": "https://registry.npmjs.org/newrelic/-/newrelic-6.7.1.tgz",
+      "integrity": "sha1-mN0vYGUH3i/d9GM2QmgKUyoc3DM=",
+      "dev": true,
+      "requires": {
+        "@grpc/grpc-js": "1.0.3",
+        "@grpc/proto-loader": "^0.5.3",
+        "@newrelic/aws-sdk": "^1.1.1",
+        "@newrelic/koa": "^3.0.0",
+        "@newrelic/native-metrics": "^5.0.0",
+        "@newrelic/superagent": "^2.0.1",
+        "@tyriar/fibonacci-heap": "^2.0.7",
+        "async": "^2.1.4",
+        "concat-stream": "^2.0.0",
+        "escodegen": "^1.11.1",
+        "esprima": "^4.0.1",
+        "https-proxy-agent": "^4.0.0",
+        "json-stringify-safe": "^5.0.0",
+        "readable-stream": "^3.1.1",
+        "semver": "^5.3.0"
+      },
+      "dependencies": {
+        "async": {
+          "version": "2.6.3",
+          "resolved": "https://registry.npmjs.org/async/-/async-2.6.3.tgz",
+          "integrity": "sha1-1yYl4jRKNlbjo61Pp0n6gymdgv8=",
+          "dev": true,
+          "requires": {
+            "lodash": "^4.17.14"
+          }
+        },
+        "concat-stream": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/concat-stream/-/concat-stream-2.0.0.tgz",
+          "integrity": "sha1-QUz1r3kKSMYKub5FJ9VtXkETPLE=",
+          "dev": true,
+          "requires": {
+            "buffer-from": "^1.0.0",
+            "inherits": "^2.0.3",
+            "readable-stream": "^3.0.2",
+            "typedarray": "^0.0.6"
+          }
+        }
+      }
     },
     "nice-try": {
       "version": "1.0.5",
@@ -5763,6 +8425,30 @@
       "requires": {
         "lower-case": "^2.0.1",
         "tslib": "^1.10.0"
+      }
+    },
+    "nocache": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/nocache/-/nocache-2.1.0.tgz",
+      "integrity": "sha1-Egyf/sQ7Vymx1d6IzXGqdaC6SR8=",
+      "dev": true
+    },
+    "node-biginteger": {
+      "version": "0.0.10",
+      "resolved": "https://registry.npmjs.org/node-biginteger/-/node-biginteger-0.0.10.tgz",
+      "integrity": "sha1-Iys3PnTRy4z3Ij43s2KEQm4zPhw=",
+      "dev": true,
+      "requires": {
+        "clone": "~0.2.0",
+        "long": "~2.1.0"
+      },
+      "dependencies": {
+        "long": {
+          "version": "2.1.0",
+          "resolved": "https://registry.npmjs.org/long/-/long-2.1.0.tgz",
+          "integrity": "sha1-6Xk5ohpla3qIuocco0qvMrJcDLE=",
+          "dev": true
+        }
       }
     },
     "node-gyp": {
@@ -5856,6 +8542,12 @@
         }
       }
     },
+    "node-modules-regexp": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/node-modules-regexp/-/node-modules-regexp-1.0.0.tgz",
+      "integrity": "sha1-jZ2+KJZKSsVxLpExZCEHxx6Q7EA=",
+      "dev": true
+    },
     "node-releases": {
       "version": "1.1.58",
       "resolved": "https://registry.npmjs.org/node-releases/-/node-releases-1.1.58.tgz",
@@ -5939,6 +8631,196 @@
       "integrity": "sha1-xkZdvwirzU2zWTF/eaxopkayj/k=",
       "requires": {
         "abbrev": "1"
+      }
+    },
+    "nordic": {
+      "version": "6.2.0",
+      "resolved": "http://registry.npm.ml.com/nordic/-/nordic-6.2.0.tgz",
+      "integrity": "sha1-fU2lXaeTcFkOyphAAA9d6f2Neq8=",
+      "dev": true,
+      "requires": {
+        "@babel/core": "~7.9.0",
+        "@babel/plugin-proposal-class-properties": "~7.8.3",
+        "@babel/plugin-transform-react-constant-elements": "~7.9.0",
+        "@babel/plugin-transform-react-inline-elements": "~7.9.0",
+        "@babel/preset-env": "~7.9.0",
+        "@babel/preset-react": "~7.9.4",
+        "@babel/register": "~7.9.0",
+        "core-js": "~2.6.11",
+        "csurf": "~1.11.0",
+        "frontend-analytics": "2.13.0",
+        "frontend-authentication": "4.4.0",
+        "frontend-config": "1.34.5",
+        "frontend-country_config": "1.6.0",
+        "frontend-env": "2.3.0",
+        "frontend-i18n": "3.7.0",
+        "frontend-image": "1.6.0",
+        "frontend-layout": "3.39.2",
+        "frontend-logger": "1.3.0",
+        "frontend-melidata": "3.7.0",
+        "frontend-page": "1.3.0",
+        "frontend-prevent-open-redirect": "1.1.1",
+        "frontend-restclient": "3.0.0",
+        "frontend-script": "4.2.1",
+        "frontend-statsd": "1.2.1",
+        "frontend-style": "4.3.0",
+        "newrelic": "~6.7.0",
+        "prop-types": "~15.7.2",
+        "ragnar": "2.0.2",
+        "react": "~16.13.1",
+        "react-declarative-head": "~1.0.6",
+        "react-dom": "~16.13.1",
+        "react-side-effect": "~2.1.0",
+        "serialize-javascript": "~3.0.0"
+      },
+      "dependencies": {
+        "@babel/core": {
+          "version": "7.9.6",
+          "resolved": "https://registry.npmjs.org/@babel/core/-/core-7.9.6.tgz",
+          "integrity": "sha1-2aofWAq/OyKG70C2kE05CQTGM3Y=",
+          "dev": true,
+          "requires": {
+            "@babel/code-frame": "^7.8.3",
+            "@babel/generator": "^7.9.6",
+            "@babel/helper-module-transforms": "^7.9.0",
+            "@babel/helpers": "^7.9.6",
+            "@babel/parser": "^7.9.6",
+            "@babel/template": "^7.8.6",
+            "@babel/traverse": "^7.9.6",
+            "@babel/types": "^7.9.6",
+            "convert-source-map": "^1.7.0",
+            "debug": "^4.1.0",
+            "gensync": "^1.0.0-beta.1",
+            "json5": "^2.1.2",
+            "lodash": "^4.17.13",
+            "resolve": "^1.3.2",
+            "semver": "^5.4.1",
+            "source-map": "^0.5.0"
+          }
+        },
+        "@babel/plugin-proposal-class-properties": {
+          "version": "7.8.3",
+          "resolved": "https://registry.npmjs.org/@babel/plugin-proposal-class-properties/-/plugin-proposal-class-properties-7.8.3.tgz",
+          "integrity": "sha1-XgZlSvXNBLYIkVqtqbKmeIAERk4=",
+          "dev": true,
+          "requires": {
+            "@babel/helper-create-class-features-plugin": "^7.8.3",
+            "@babel/helper-plugin-utils": "^7.8.3"
+          }
+        },
+        "@babel/preset-env": {
+          "version": "7.9.6",
+          "resolved": "https://registry.npmjs.org/@babel/preset-env/-/preset-env-7.9.6.tgz",
+          "integrity": "sha1-3wY7J2xkVexvz8blOqzDjamwrqY=",
+          "dev": true,
+          "requires": {
+            "@babel/compat-data": "^7.9.6",
+            "@babel/helper-compilation-targets": "^7.9.6",
+            "@babel/helper-module-imports": "^7.8.3",
+            "@babel/helper-plugin-utils": "^7.8.3",
+            "@babel/plugin-proposal-async-generator-functions": "^7.8.3",
+            "@babel/plugin-proposal-dynamic-import": "^7.8.3",
+            "@babel/plugin-proposal-json-strings": "^7.8.3",
+            "@babel/plugin-proposal-nullish-coalescing-operator": "^7.8.3",
+            "@babel/plugin-proposal-numeric-separator": "^7.8.3",
+            "@babel/plugin-proposal-object-rest-spread": "^7.9.6",
+            "@babel/plugin-proposal-optional-catch-binding": "^7.8.3",
+            "@babel/plugin-proposal-optional-chaining": "^7.9.0",
+            "@babel/plugin-proposal-unicode-property-regex": "^7.8.3",
+            "@babel/plugin-syntax-async-generators": "^7.8.0",
+            "@babel/plugin-syntax-dynamic-import": "^7.8.0",
+            "@babel/plugin-syntax-json-strings": "^7.8.0",
+            "@babel/plugin-syntax-nullish-coalescing-operator": "^7.8.0",
+            "@babel/plugin-syntax-numeric-separator": "^7.8.0",
+            "@babel/plugin-syntax-object-rest-spread": "^7.8.0",
+            "@babel/plugin-syntax-optional-catch-binding": "^7.8.0",
+            "@babel/plugin-syntax-optional-chaining": "^7.8.0",
+            "@babel/plugin-syntax-top-level-await": "^7.8.3",
+            "@babel/plugin-transform-arrow-functions": "^7.8.3",
+            "@babel/plugin-transform-async-to-generator": "^7.8.3",
+            "@babel/plugin-transform-block-scoped-functions": "^7.8.3",
+            "@babel/plugin-transform-block-scoping": "^7.8.3",
+            "@babel/plugin-transform-classes": "^7.9.5",
+            "@babel/plugin-transform-computed-properties": "^7.8.3",
+            "@babel/plugin-transform-destructuring": "^7.9.5",
+            "@babel/plugin-transform-dotall-regex": "^7.8.3",
+            "@babel/plugin-transform-duplicate-keys": "^7.8.3",
+            "@babel/plugin-transform-exponentiation-operator": "^7.8.3",
+            "@babel/plugin-transform-for-of": "^7.9.0",
+            "@babel/plugin-transform-function-name": "^7.8.3",
+            "@babel/plugin-transform-literals": "^7.8.3",
+            "@babel/plugin-transform-member-expression-literals": "^7.8.3",
+            "@babel/plugin-transform-modules-amd": "^7.9.6",
+            "@babel/plugin-transform-modules-commonjs": "^7.9.6",
+            "@babel/plugin-transform-modules-systemjs": "^7.9.6",
+            "@babel/plugin-transform-modules-umd": "^7.9.0",
+            "@babel/plugin-transform-named-capturing-groups-regex": "^7.8.3",
+            "@babel/plugin-transform-new-target": "^7.8.3",
+            "@babel/plugin-transform-object-super": "^7.8.3",
+            "@babel/plugin-transform-parameters": "^7.9.5",
+            "@babel/plugin-transform-property-literals": "^7.8.3",
+            "@babel/plugin-transform-regenerator": "^7.8.7",
+            "@babel/plugin-transform-reserved-words": "^7.8.3",
+            "@babel/plugin-transform-shorthand-properties": "^7.8.3",
+            "@babel/plugin-transform-spread": "^7.8.3",
+            "@babel/plugin-transform-sticky-regex": "^7.8.3",
+            "@babel/plugin-transform-template-literals": "^7.8.3",
+            "@babel/plugin-transform-typeof-symbol": "^7.8.4",
+            "@babel/plugin-transform-unicode-regex": "^7.8.3",
+            "@babel/preset-modules": "^0.1.3",
+            "@babel/types": "^7.9.6",
+            "browserslist": "^4.11.1",
+            "core-js-compat": "^3.6.2",
+            "invariant": "^2.2.2",
+            "levenary": "^1.1.1",
+            "semver": "^5.5.0"
+          }
+        },
+        "@babel/preset-react": {
+          "version": "7.9.4",
+          "resolved": "https://registry.npmjs.org/@babel/preset-react/-/preset-react-7.9.4.tgz",
+          "integrity": "sha1-xsl2k6xltrnAtPJblIqPZlRjAU0=",
+          "dev": true,
+          "requires": {
+            "@babel/helper-plugin-utils": "^7.8.3",
+            "@babel/plugin-transform-react-display-name": "^7.8.3",
+            "@babel/plugin-transform-react-jsx": "^7.9.4",
+            "@babel/plugin-transform-react-jsx-development": "^7.9.0",
+            "@babel/plugin-transform-react-jsx-self": "^7.9.0",
+            "@babel/plugin-transform-react-jsx-source": "^7.9.0"
+          }
+        },
+        "serialize-javascript": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/serialize-javascript/-/serialize-javascript-3.0.0.tgz",
+          "integrity": "sha1-SS5Imi13t7gErTkaX12XhwlSVI4=",
+          "dev": true
+        }
+      }
+    },
+    "nordic-attribution": {
+      "version": "1.6.5",
+      "resolved": "http://registry.npm.ml.com/nordic-attribution/-/nordic-attribution-1.6.5.tgz",
+      "integrity": "sha1-6PAT6BGCCG2YuoSnDbUPSsr+8lI=",
+      "dev": true
+    },
+    "nordic-axios": {
+      "version": "3.0.0",
+      "resolved": "http://registry.npm.ml.com/nordic-axios/-/nordic-axios-3.0.0.tgz",
+      "integrity": "sha1-5ByDLHRyuNqV93RHoSUgZBb9ey8=",
+      "dev": true,
+      "requires": {
+        "follow-redirects": "1.5.10",
+        "frontend-statsd": "^1.2.0",
+        "is-buffer": "^2.0.2"
+      },
+      "dependencies": {
+        "is-buffer": {
+          "version": "2.0.4",
+          "resolved": "https://registry.npmjs.org/is-buffer/-/is-buffer-2.0.4.tgz",
+          "integrity": "sha1-PlcvI8hBGlz9lVfISeNmXgspBiM=",
+          "dev": true
+        }
       }
     },
     "normalize-package-data": {
@@ -6075,12 +8957,59 @@
         "isobject": "^3.0.1"
       }
     },
+    "object.values": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/object.values/-/object.values-1.1.1.tgz",
+      "integrity": "sha1-aKmezeNWt+kpWjxeDOMdyMlT3l4=",
+      "dev": true,
+      "requires": {
+        "define-properties": "^1.1.3",
+        "es-abstract": "^1.17.0-next.1",
+        "function-bind": "^1.1.1",
+        "has": "^1.0.3"
+      }
+    },
+    "on-finished": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/on-finished/-/on-finished-2.3.0.tgz",
+      "integrity": "sha1-IPEzZIGwg811M3mSoWlxqi2QaUc=",
+      "dev": true,
+      "requires": {
+        "ee-first": "1.1.1"
+      }
+    },
+    "on-headers": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/on-headers/-/on-headers-1.0.2.tgz",
+      "integrity": "sha1-dysK5qqlJcOZ5Imt+tkMQD6zwo8=",
+      "dev": true
+    },
     "once": {
       "version": "1.4.0",
       "resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
       "integrity": "sha1-WDsap3WWHUsROsF9nFC6753Xa9E=",
       "requires": {
         "wrappy": "1"
+      }
+    },
+    "one-time": {
+      "version": "0.0.4",
+      "resolved": "https://registry.npmjs.org/one-time/-/one-time-0.0.4.tgz",
+      "integrity": "sha1-+M33eISCb+Tf+T46nMN7HkSAdC4=",
+      "dev": true
+    },
+    "optionator": {
+      "version": "0.8.3",
+      "resolved": "https://registry.npmjs.org/optionator/-/optionator-0.8.3.tgz",
+      "integrity": "sha1-hPodA2/p08fiHZmIS2ARZ+yPtJU=",
+      "dev": true,
+      "requires": {
+        "deep-is": "~0.1.3",
+        "fast-levenshtein": "~2.0.6",
+        "levn": "~0.3.0",
+        "prelude-ls": "~1.1.2",
+        "type-check": "~0.3.2",
+        "word-wrap": "~1.2.3"
       }
     },
     "os-browserify": {
@@ -6093,6 +9022,15 @@
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/os-homedir/-/os-homedir-1.0.2.tgz",
       "integrity": "sha1-/7xJiDNuDoM94MFox+8VISGqf7M="
+    },
+    "os-locale": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/os-locale/-/os-locale-1.4.0.tgz",
+      "integrity": "sha1-IPnxeuKe00XoveWDsT0gCYA8FNk=",
+      "dev": true,
+      "requires": {
+        "lcid": "^1.0.0"
+      }
     },
     "os-tmpdir": {
       "version": "1.0.2",
@@ -6216,6 +9154,12 @@
       "integrity": "sha1-8r0iH2zJcKk42IVWq8WJyqqiveE=",
       "dev": true
     },
+    "parseurl": {
+      "version": "1.3.3",
+      "resolved": "https://registry.npmjs.org/parseurl/-/parseurl-1.3.3.tgz",
+      "integrity": "sha1-naGee+6NEt/wUT7Vt2lXeTvC6NQ=",
+      "dev": true
+    },
     "pascal-case": {
       "version": "3.1.1",
       "resolved": "https://registry.npmjs.org/pascal-case/-/pascal-case-3.1.1.tgz",
@@ -6264,6 +9208,12 @@
       "version": "1.0.6",
       "resolved": "https://registry.npmjs.org/path-parse/-/path-parse-1.0.6.tgz",
       "integrity": "sha512-GSmOT2EbHrINBf9SR7CDELwlJ8AENk3Qn7OikK4nFYAu3Ote2+JYNVvkpAEQm3/TLNEJFD/xZJjzyxg3KBWOzw=="
+    },
+    "path-to-regexp": {
+      "version": "0.1.7",
+      "resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-0.1.7.tgz",
+      "integrity": "sha1-32BBeABfUi8V60SQ5yR6G/qmf4w=",
+      "dev": true
     },
     "path-type": {
       "version": "1.1.0",
@@ -6326,6 +9276,15 @@
         "pinkie": "^2.0.0"
       }
     },
+    "pirates": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/pirates/-/pirates-4.0.1.tgz",
+      "integrity": "sha1-ZDqSyviUVm+RsrmG0sZpUKji+4c=",
+      "dev": true,
+      "requires": {
+        "node-modules-regexp": "^1.0.0"
+      }
+    },
     "pkg-dir": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/pkg-dir/-/pkg-dir-3.0.0.tgz",
@@ -6333,6 +9292,25 @@
       "dev": true,
       "requires": {
         "find-up": "^3.0.0"
+      }
+    },
+    "po2json": {
+      "version": "1.0.0-alpha",
+      "resolved": "https://registry.npmjs.org/po2json/-/po2json-1.0.0-alpha.tgz",
+      "integrity": "sha1-dcL5hztnfrTNvTXyDS0CnaOcHsU=",
+      "dev": true,
+      "requires": {
+        "commander": "^2.18.0",
+        "gettext-parser": "2.0.0",
+        "gettext-to-messageformat": "^0.3.0"
+      },
+      "dependencies": {
+        "commander": {
+          "version": "2.20.3",
+          "resolved": "https://registry.npmjs.org/commander/-/commander-2.20.3.tgz",
+          "integrity": "sha1-/UhehMA+tIgcIHIrpIA16FMa6zM=",
+          "dev": true
+        }
       }
     },
     "posix-character-classes": {
@@ -6427,6 +9405,34 @@
       "integrity": "sha512-97DXOFbQJhk71ne5/Mt6cOu6yxsSfM0QGQyl0L25Gca4yGWEGJaig7l7gbCX623VqTBNGLRLaVUCnNkcedlRSQ==",
       "dev": true
     },
+    "prelude-ls": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/prelude-ls/-/prelude-ls-1.1.2.tgz",
+      "integrity": "sha1-IZMqVJ9eUv/ZqCf1cOBL5iqX2lQ=",
+      "dev": true
+    },
+    "pretty": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/pretty/-/pretty-2.0.0.tgz",
+      "integrity": "sha1-rbx5YLe7/iiaVX3F9zdhmiINBqU=",
+      "dev": true,
+      "requires": {
+        "condense-newlines": "^0.2.1",
+        "extend-shallow": "^2.0.1",
+        "js-beautify": "^1.6.12"
+      },
+      "dependencies": {
+        "extend-shallow": {
+          "version": "2.0.1",
+          "resolved": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-2.0.1.tgz",
+          "integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
+          "dev": true,
+          "requires": {
+            "is-extendable": "^0.1.0"
+          }
+        }
+      }
+    },
     "pretty-error": {
       "version": "2.1.1",
       "resolved": "https://registry.npmjs.org/pretty-error/-/pretty-error-2.1.1.tgz",
@@ -6468,6 +9474,51 @@
         "loose-envify": "^1.4.0",
         "object-assign": "^4.1.1",
         "react-is": "^16.8.1"
+      }
+    },
+    "proto-list": {
+      "version": "1.2.4",
+      "resolved": "https://registry.npmjs.org/proto-list/-/proto-list-1.2.4.tgz",
+      "integrity": "sha1-IS1b/hMYMGpCD2QCuOJv85ZHqEk=",
+      "dev": true
+    },
+    "protobufjs": {
+      "version": "6.9.0",
+      "resolved": "https://registry.npmjs.org/protobufjs/-/protobufjs-6.9.0.tgz",
+      "integrity": "sha1-wIsr9jZoJZjm+rvw7bCxJW/wkL0=",
+      "dev": true,
+      "requires": {
+        "@protobufjs/aspromise": "^1.1.2",
+        "@protobufjs/base64": "^1.1.2",
+        "@protobufjs/codegen": "^2.0.4",
+        "@protobufjs/eventemitter": "^1.1.0",
+        "@protobufjs/fetch": "^1.1.0",
+        "@protobufjs/float": "^1.0.2",
+        "@protobufjs/inquire": "^1.1.0",
+        "@protobufjs/path": "^1.1.2",
+        "@protobufjs/pool": "^1.1.0",
+        "@protobufjs/utf8": "^1.1.0",
+        "@types/long": "^4.0.1",
+        "@types/node": "^13.7.0",
+        "long": "^4.0.0"
+      },
+      "dependencies": {
+        "@types/node": {
+          "version": "13.13.13",
+          "resolved": "https://registry.npmjs.org/@types/node/-/node-13.13.13.tgz",
+          "integrity": "sha1-cSF9kP2cnJN+KGKHctXAtDLHk1U=",
+          "dev": true
+        }
+      }
+    },
+    "proxy-addr": {
+      "version": "2.0.6",
+      "resolved": "https://registry.npmjs.org/proxy-addr/-/proxy-addr-2.0.6.tgz",
+      "integrity": "sha1-/cIzZQVEfT8vLGOO0nLK9hS7sr8=",
+      "dev": true,
+      "requires": {
+        "forwarded": "~0.1.2",
+        "ipaddr.js": "1.9.1"
       }
     },
     "prr": {
@@ -6546,10 +9597,27 @@
       "resolved": "https://registry.npmjs.org/punycode/-/punycode-2.1.1.tgz",
       "integrity": "sha512-XRsRjdf+j5ml+y/6GKHPZbrF/8p2Yga0JPtdqTIY2Xe5ohJPD9saDJJLPvp9+NSBprVvevdXZybnj2cv8OEd0A=="
     },
+    "q": {
+      "version": "1.5.1",
+      "resolved": "https://registry.npmjs.org/q/-/q-1.5.1.tgz",
+      "integrity": "sha1-fjL3W0E4EpHQRhHxvxQQmsAGUdc=",
+      "dev": true
+    },
     "qs": {
       "version": "6.5.2",
       "resolved": "https://registry.npmjs.org/qs/-/qs-6.5.2.tgz",
       "integrity": "sha512-N5ZAX4/LxJmF+7wN74pUD6qAh9/wnvdQcjq9TZjevvXzSUo7bfmw91saqMjzGS2xq91/odN2dW/WOl7qQHNDGA=="
+    },
+    "query-string": {
+      "version": "6.13.1",
+      "resolved": "https://registry.npmjs.org/query-string/-/query-string-6.13.1.tgz",
+      "integrity": "sha1-2RPM/OO0s6cTmJ/m05Rm2S5xzK0=",
+      "dev": true,
+      "requires": {
+        "decode-uri-component": "^0.2.0",
+        "split-on-first": "^1.0.0",
+        "strict-uri-encode": "^2.0.0"
+      }
     },
     "querystring": {
       "version": "0.2.0",
@@ -6561,6 +9629,52 @@
       "version": "0.2.1",
       "resolved": "https://registry.npmjs.org/querystring-es3/-/querystring-es3-0.2.1.tgz",
       "integrity": "sha1-nsYfeQSYdXB9aUFFlv2Qek1xHnM=",
+      "dev": true
+    },
+    "ragnar": {
+      "version": "2.0.2",
+      "resolved": "http://registry.npm.ml.com/ragnar/-/ragnar-2.0.2.tgz",
+      "integrity": "sha1-it6UVVl9N5FPsZNtBad4h4NOwwY=",
+      "dev": true,
+      "requires": {
+        "body-parser": "1.19.0",
+        "cbt-users-middleware": "^1.0.0",
+        "compression": "1.7.4",
+        "connect-flash": "0.1.1",
+        "cookie-parser": "1.4.4",
+        "express": "4.17.1",
+        "frontend-authentication": "^4.3.0",
+        "frontend-config": "^1.31.12",
+        "frontend-device_detection": "^1.10.0",
+        "frontend-env": "^2.3.0",
+        "frontend-logger": "^1.3.0",
+        "frontend-mshops-detection": "^1.0.0",
+        "frontend-platform_detection": "^1.5.0",
+        "frontend-restclient": "^3.0.0",
+        "frontend-statsd": "^1.2.0",
+        "fury-session": "1.3.3",
+        "helmet": "3.21.1",
+        "hpp": "0.2.2",
+        "launch-editor-middleware": "2.2.1",
+        "lodash.merge": "4.6.2",
+        "morgan": "1.9.1",
+        "statuses": "1.5.0",
+        "uuid": "3.3.3",
+        "youch": "2.0.10"
+      },
+      "dependencies": {
+        "uuid": {
+          "version": "3.3.3",
+          "resolved": "https://registry.npmjs.org/uuid/-/uuid-3.3.3.tgz",
+          "integrity": "sha1-RWjwIW54dg7h2/Ok0s9T4iQRKGY=",
+          "dev": true
+        }
+      }
+    },
+    "random-bytes": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/random-bytes/-/random-bytes-1.0.0.tgz",
+      "integrity": "sha1-T2ih3Arli9P7lYSMMDJNt11kNgs=",
       "dev": true
     },
     "randombytes": {
@@ -6580,6 +9694,45 @@
       "requires": {
         "randombytes": "^2.0.5",
         "safe-buffer": "^5.1.0"
+      }
+    },
+    "range-parser": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/range-parser/-/range-parser-1.2.1.tgz",
+      "integrity": "sha1-PPNwI9GZ4cJNGlW4SADC8+ZGgDE=",
+      "dev": true
+    },
+    "raw-body": {
+      "version": "2.4.0",
+      "resolved": "https://registry.npmjs.org/raw-body/-/raw-body-2.4.0.tgz",
+      "integrity": "sha1-oc5vucm8NWylLoklarWQWeE9AzI=",
+      "dev": true,
+      "requires": {
+        "bytes": "3.1.0",
+        "http-errors": "1.7.2",
+        "iconv-lite": "0.4.24",
+        "unpipe": "1.0.0"
+      },
+      "dependencies": {
+        "http-errors": {
+          "version": "1.7.2",
+          "resolved": "https://registry.npmjs.org/http-errors/-/http-errors-1.7.2.tgz",
+          "integrity": "sha1-T1ApzxMjnzEDblsuVSkrz7zIXI8=",
+          "dev": true,
+          "requires": {
+            "depd": "~1.1.2",
+            "inherits": "2.0.3",
+            "setprototypeof": "1.1.1",
+            "statuses": ">= 1.5.0 < 2",
+            "toidentifier": "1.0.0"
+          }
+        },
+        "inherits": {
+          "version": "2.0.3",
+          "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.3.tgz",
+          "integrity": "sha1-Yzwsg+PaQqUC9SRmAiSA9CCCYd4=",
+          "dev": true
+        }
       }
     },
     "raw-loader": {
@@ -6602,6 +9755,15 @@
         "prop-types": "^15.6.2"
       }
     },
+    "react-declarative-head": {
+      "version": "1.0.6",
+      "resolved": "http://registry.npm.ml.com/react-declarative-head/-/react-declarative-head-1.0.6.tgz",
+      "integrity": "sha1-WfeOFl4XktmCKIVwTubDHPDD4W0=",
+      "dev": true,
+      "requires": {
+        "shallowequal": "^0.2.2"
+      }
+    },
     "react-dom": {
       "version": "16.13.1",
       "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-16.13.1.tgz",
@@ -6618,6 +9780,18 @@
       "version": "16.13.1",
       "resolved": "https://registry.npmjs.org/react-is/-/react-is-16.13.1.tgz",
       "integrity": "sha512-24e6ynE2H+OKt4kqsOvNd8kBpV65zoxbA4BVsEOB3ARVWQki/DHzaUoC5KuON/BiccDaCCTZBuOcfZs70kR8bQ=="
+    },
+    "react-property": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/react-property/-/react-property-1.0.1.tgz",
+      "integrity": "sha1-SuQhFVfQoK4FCnGqitKIwHS+pOY=",
+      "dev": true
+    },
+    "react-side-effect": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/react-side-effect/-/react-side-effect-2.1.0.tgz",
+      "integrity": "sha1-HOSotERRaMSH7STauIZCH3TTgNM=",
+      "dev": true
     },
     "read-pkg": {
       "version": "1.1.0",
@@ -6685,6 +9859,12 @@
         "indent-string": "^2.1.0",
         "strip-indent": "^1.0.1"
       }
+    },
+    "referrer-policy": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/referrer-policy/-/referrer-policy-1.2.0.tgz",
+      "integrity": "sha1-uZz7i1cJDcRUiV74l6TMNe9nqY4=",
+      "dev": true
     },
     "regenerate": {
       "version": "1.4.1",
@@ -6958,6 +10138,12 @@
       "integrity": "sha512-TTlYpa+OL+vMMNG24xSlQGEJ3B/RzEfUlLct7b5G/ytav+wPrplCpVMFuwzXbkecJrb6IYo1iFb0S9v37754mg==",
       "dev": true
     },
+    "retry": {
+      "version": "0.12.0",
+      "resolved": "https://registry.npmjs.org/retry/-/retry-0.12.0.tgz",
+      "integrity": "sha1-G0KmJmoh8HQh0bC1S33BZ7AcATs=",
+      "dev": true
+    },
     "rimraf": {
       "version": "2.7.1",
       "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-2.7.1.tgz",
@@ -6975,6 +10161,12 @@
         "hash-base": "^3.0.0",
         "inherits": "^2.0.1"
       }
+    },
+    "rndm": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/rndm/-/rndm-1.2.0.tgz",
+      "integrity": "sha1-8z/pz7Urv9UgqhgyO8ZdsRCht2w=",
+      "dev": true
     },
     "run-queue": {
       "version": "1.0.3",
@@ -7056,6 +10248,12 @@
         }
       }
     },
+    "sax": {
+      "version": "1.2.4",
+      "resolved": "https://registry.npmjs.org/sax/-/sax-1.2.4.tgz",
+      "integrity": "sha1-KBYjTiN4vdxOU1T6tcqold9xANk=",
+      "dev": true
+    },
     "scheduler": {
       "version": "0.19.1",
       "resolved": "https://registry.npmjs.org/scheduler/-/scheduler-0.19.1.tgz",
@@ -7101,6 +10299,52 @@
       "resolved": "https://registry.npmjs.org/semver/-/semver-5.7.1.tgz",
       "integrity": "sha512-sauaDf/PZdVgrLTNYHRtpXa1iRiKcaebiKQ1BJdpQlWH2lCvexQdX55snPFyK7QzpudqbCI0qXFfOasHdyNDGQ=="
     },
+    "send": {
+      "version": "0.17.1",
+      "resolved": "https://registry.npmjs.org/send/-/send-0.17.1.tgz",
+      "integrity": "sha1-wdiwWfeQD3Rm3Uk4vcROEd2zdsg=",
+      "dev": true,
+      "requires": {
+        "debug": "2.6.9",
+        "depd": "~1.1.2",
+        "destroy": "~1.0.4",
+        "encodeurl": "~1.0.2",
+        "escape-html": "~1.0.3",
+        "etag": "~1.8.1",
+        "fresh": "0.5.2",
+        "http-errors": "~1.7.2",
+        "mime": "1.6.0",
+        "ms": "2.1.1",
+        "on-finished": "~2.3.0",
+        "range-parser": "~1.2.1",
+        "statuses": "~1.5.0"
+      },
+      "dependencies": {
+        "debug": {
+          "version": "2.6.9",
+          "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
+          "integrity": "sha1-XRKFFd8TT/Mn6QpMk/Tgd6U2NB8=",
+          "dev": true,
+          "requires": {
+            "ms": "2.0.0"
+          },
+          "dependencies": {
+            "ms": {
+              "version": "2.0.0",
+              "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
+              "integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g=",
+              "dev": true
+            }
+          }
+        },
+        "ms": {
+          "version": "2.1.1",
+          "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.1.tgz",
+          "integrity": "sha1-MKWGTrPrsKZvLr5tcnrwagnYbgo=",
+          "dev": true
+        }
+      }
+    },
     "serialize-javascript": {
       "version": "3.1.0",
       "resolved": "https://registry.npmjs.org/serialize-javascript/-/serialize-javascript-3.1.0.tgz",
@@ -7108,6 +10352,18 @@
       "dev": true,
       "requires": {
         "randombytes": "^2.1.0"
+      }
+    },
+    "serve-static": {
+      "version": "1.14.1",
+      "resolved": "https://registry.npmjs.org/serve-static/-/serve-static-1.14.1.tgz",
+      "integrity": "sha1-Zm5jbcTwEPfvKZcKiKZ0MgiYsvk=",
+      "dev": true,
+      "requires": {
+        "encodeurl": "~1.0.2",
+        "escape-html": "~1.0.3",
+        "parseurl": "~1.3.3",
+        "send": "0.17.1"
       }
     },
     "set-blocking": {
@@ -7144,6 +10400,12 @@
       "integrity": "sha1-KQy7Iy4waULX1+qbg3Mqt4VvgoU=",
       "dev": true
     },
+    "setprototypeof": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/setprototypeof/-/setprototypeof-1.1.1.tgz",
+      "integrity": "sha1-fpWsskqpL1iF4KvvW6ExMw1K5oM=",
+      "dev": true
+    },
     "sha.js": {
       "version": "2.4.11",
       "resolved": "https://registry.npmjs.org/sha.js/-/sha.js-2.4.11.tgz",
@@ -7163,6 +10425,15 @@
         "kind-of": "^6.0.2"
       }
     },
+    "shallowequal": {
+      "version": "0.2.2",
+      "resolved": "https://registry.npmjs.org/shallowequal/-/shallowequal-0.2.2.tgz",
+      "integrity": "sha1-HjL9W8q2rWiKSBLLDMBO/HXHAU4=",
+      "dev": true,
+      "requires": {
+        "lodash.keys": "^3.1.2"
+      }
+    },
     "shebang-command": {
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/shebang-command/-/shebang-command-1.2.0.tgz",
@@ -7176,10 +10447,45 @@
       "resolved": "https://registry.npmjs.org/shebang-regex/-/shebang-regex-1.0.0.tgz",
       "integrity": "sha1-2kL0l0DAtC2yypcoVxyxkMmO/qM="
     },
+    "shell-quote": {
+      "version": "1.7.2",
+      "resolved": "https://registry.npmjs.org/shell-quote/-/shell-quote-1.7.2.tgz",
+      "integrity": "sha1-Z6fQLHbJ2iT5nSCAj8re0ODgS+I=",
+      "dev": true
+    },
+    "sigmund": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/sigmund/-/sigmund-1.0.1.tgz",
+      "integrity": "sha1-P/IfGYytIXX587eBhT/ZTQ0ZtZA=",
+      "dev": true
+    },
     "signal-exit": {
       "version": "3.0.3",
       "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-3.0.3.tgz",
       "integrity": "sha512-VUJ49FC8U1OxwZLxIbTTrDvLnf/6TDgxZcK8wxR8zs13xpx7xbG60ndBlhNrFi2EMuFRoeDoJO7wthSLq42EjA=="
+    },
+    "simple-lru-cache": {
+      "version": "0.0.2",
+      "resolved": "https://registry.npmjs.org/simple-lru-cache/-/simple-lru-cache-0.0.2.tgz",
+      "integrity": "sha1-1ZzDoZPBpdAyD4Tucy9uRxPlEd0=",
+      "dev": true
+    },
+    "simple-swizzle": {
+      "version": "0.2.2",
+      "resolved": "https://registry.npmjs.org/simple-swizzle/-/simple-swizzle-0.2.2.tgz",
+      "integrity": "sha1-pNprY1/8zMoz9w0Xy5JZLeleVXo=",
+      "dev": true,
+      "requires": {
+        "is-arrayish": "^0.3.1"
+      },
+      "dependencies": {
+        "is-arrayish": {
+          "version": "0.3.2",
+          "resolved": "https://registry.npmjs.org/is-arrayish/-/is-arrayish-0.3.2.tgz",
+          "integrity": "sha1-RXSirlb3qyBolvtDHq7tBm/fjwM=",
+          "dev": true
+        }
+      }
     },
     "slash": {
       "version": "1.0.0",
@@ -7391,6 +10697,12 @@
       "resolved": "https://registry.npmjs.org/spdx-license-ids/-/spdx-license-ids-3.0.5.tgz",
       "integrity": "sha512-J+FWzZoynJEXGphVIS+XEh3kFSjZX/1i9gFBaWQcB+/tmpe2qUsSBABpcxqxnAxFdiUFEgAX1bjYGQvIZmoz9Q=="
     },
+    "split-on-first": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/split-on-first/-/split-on-first-1.1.0.tgz",
+      "integrity": "sha1-9hCv7uOxK84dDDBCXnY5i3gkml8=",
+      "dev": true
+    },
     "split-string": {
       "version": "3.1.0",
       "resolved": "https://registry.npmjs.org/split-string/-/split-string-3.1.0.tgz",
@@ -7399,6 +10711,12 @@
       "requires": {
         "extend-shallow": "^3.0.0"
       }
+    },
+    "sprintf-js": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/sprintf-js/-/sprintf-js-1.0.3.tgz",
+      "integrity": "sha1-BOaSb2YolTVPPdAVIDYzuFcpfiw=",
+      "dev": true
     },
     "sshpk": {
       "version": "1.16.1",
@@ -7425,6 +10743,35 @@
         "figgy-pudding": "^3.5.1"
       }
     },
+    "stable": {
+      "version": "0.1.8",
+      "resolved": "https://registry.npmjs.org/stable/-/stable-0.1.8.tgz",
+      "integrity": "sha1-g26zyDgv4pNv6vVEYxAXzn1Ho88=",
+      "dev": true
+    },
+    "stack-trace": {
+      "version": "0.0.10",
+      "resolved": "https://registry.npmjs.org/stack-trace/-/stack-trace-0.0.10.tgz",
+      "integrity": "sha1-VHxws0fo0ytOEI6hoqFZ5f3eGcA=",
+      "dev": true
+    },
+    "stale-lru-cache": {
+      "version": "5.1.1",
+      "resolved": "https://registry.npmjs.org/stale-lru-cache/-/stale-lru-cache-5.1.1.tgz",
+      "integrity": "sha1-MoLDpxSMdOPHhYeZEwr53TQHyEU=",
+      "dev": true,
+      "requires": {
+        "yallist": "^2.0.0"
+      },
+      "dependencies": {
+        "yallist": {
+          "version": "2.1.2",
+          "resolved": "https://registry.npmjs.org/yallist/-/yallist-2.1.2.tgz",
+          "integrity": "sha1-HBH5IY8HYImkfdUS+TxmmaaoHVI=",
+          "dev": true
+        }
+      }
+    },
     "static-extend": {
       "version": "0.1.2",
       "resolved": "https://registry.npmjs.org/static-extend/-/static-extend-0.1.2.tgz",
@@ -7445,6 +10792,12 @@
           }
         }
       }
+    },
+    "statuses": {
+      "version": "1.5.0",
+      "resolved": "https://registry.npmjs.org/statuses/-/statuses-1.5.0.tgz",
+      "integrity": "sha1-Fhx9rBd2Wf2YEfQ3cfqZOBR4Yow=",
+      "dev": true
     },
     "stdout-stream": {
       "version": "1.4.1",
@@ -7569,6 +10922,18 @@
       "integrity": "sha512-AiisoFqQ0vbGcZgQPY1cdP2I76glaVA/RauYR4G4thNFgkTqr90yXTo4LYX60Jl+sIlPNHHdGSwo01AvbKUSVQ==",
       "dev": true
     },
+    "strict-uri-encode": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/strict-uri-encode/-/strict-uri-encode-2.0.0.tgz",
+      "integrity": "sha1-ucczDHBChi9rFC3CdLvMWGbONUY=",
+      "dev": true
+    },
+    "string-hash": {
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/string-hash/-/string-hash-1.1.3.tgz",
+      "integrity": "sha1-6Kr8CsGFW0Zmkp7X3RJ1311sgRs=",
+      "dev": true
+    },
     "string-width": {
       "version": "3.1.0",
       "resolved": "https://registry.npmjs.org/string-width/-/string-width-3.1.0.tgz",
@@ -7663,12 +11028,161 @@
         "schema-utils": "^2.6.6"
       }
     },
+    "style-to-object": {
+      "version": "0.3.0",
+      "resolved": "https://registry.npmjs.org/style-to-object/-/style-to-object-0.3.0.tgz",
+      "integrity": "sha1-sbeQ0gWZHMeDgBlnIUl57hmnbkY=",
+      "dev": true,
+      "requires": {
+        "inline-style-parser": "0.1.1"
+      }
+    },
     "supports-color": {
       "version": "5.5.0",
       "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.5.0.tgz",
       "integrity": "sha512-QjVjwdXIt408MIiAqCX4oUKsgU2EqAGzs2Ppkm4aQYbjm+ZEWEcW4SfFNTr4uMNZma0ey4f5lgLrkB0aX0QMow==",
       "requires": {
         "has-flag": "^3.0.0"
+      }
+    },
+    "svg-to-jsx": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/svg-to-jsx/-/svg-to-jsx-1.0.2.tgz",
+      "integrity": "sha1-EhjeUAo+JmH+mBBIctbJwapAn0U=",
+      "dev": true,
+      "requires": {
+        "object-assign": "^4.0.1",
+        "q": "^1.4.1",
+        "xml2js": "^0.4.10",
+        "xmlbuilder": "^13.0.2",
+        "yargs": "^3.21.0"
+      },
+      "dependencies": {
+        "camelcase": {
+          "version": "2.1.1",
+          "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-2.1.1.tgz",
+          "integrity": "sha1-fB0W1nmhu+WcoCys7PsBHiAfWh8=",
+          "dev": true
+        },
+        "cliui": {
+          "version": "3.2.0",
+          "resolved": "https://registry.npmjs.org/cliui/-/cliui-3.2.0.tgz",
+          "integrity": "sha1-EgYBU3qRbSmUD5NNo7SNWFo5IT0=",
+          "dev": true,
+          "requires": {
+            "string-width": "^1.0.1",
+            "strip-ansi": "^3.0.1",
+            "wrap-ansi": "^2.0.0"
+          }
+        },
+        "is-fullwidth-code-point": {
+          "version": "1.0.0",
+          "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-1.0.0.tgz",
+          "integrity": "sha1-754xOG8DGn8NZDr4L95QxFfvAMs=",
+          "dev": true,
+          "requires": {
+            "number-is-nan": "^1.0.0"
+          }
+        },
+        "string-width": {
+          "version": "1.0.2",
+          "resolved": "https://registry.npmjs.org/string-width/-/string-width-1.0.2.tgz",
+          "integrity": "sha1-EYvfW4zcUaKn5w0hHgfisLmxB9M=",
+          "dev": true,
+          "requires": {
+            "code-point-at": "^1.0.0",
+            "is-fullwidth-code-point": "^1.0.0",
+            "strip-ansi": "^3.0.0"
+          }
+        },
+        "wrap-ansi": {
+          "version": "2.1.0",
+          "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-2.1.0.tgz",
+          "integrity": "sha1-2Pw9KE3QV5T+hJc8rs3Rz4JP3YU=",
+          "dev": true,
+          "requires": {
+            "string-width": "^1.0.1",
+            "strip-ansi": "^3.0.1"
+          }
+        },
+        "y18n": {
+          "version": "3.2.1",
+          "resolved": "https://registry.npmjs.org/y18n/-/y18n-3.2.1.tgz",
+          "integrity": "sha1-bRX7qITAhnnA136I53WegR4H+kE=",
+          "dev": true
+        },
+        "yargs": {
+          "version": "3.32.0",
+          "resolved": "https://registry.npmjs.org/yargs/-/yargs-3.32.0.tgz",
+          "integrity": "sha1-AwiOnr+edWtpdRYR0qXvWRSCyZU=",
+          "dev": true,
+          "requires": {
+            "camelcase": "^2.0.1",
+            "cliui": "^3.0.3",
+            "decamelize": "^1.1.1",
+            "os-locale": "^1.4.0",
+            "string-width": "^1.0.1",
+            "window-size": "^0.1.4",
+            "y18n": "^3.2.0"
+          }
+        }
+      }
+    },
+    "svgo": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/svgo/-/svgo-1.3.0.tgz",
+      "integrity": "sha1-uuUbqV3tmjOja3xGzpw1mukVQxM=",
+      "dev": true,
+      "requires": {
+        "chalk": "^2.4.1",
+        "coa": "^2.0.2",
+        "css-select": "^2.0.0",
+        "css-select-base-adapter": "^0.1.1",
+        "css-tree": "1.0.0-alpha.33",
+        "csso": "^3.5.1",
+        "js-yaml": "^3.13.1",
+        "mkdirp": "~0.5.1",
+        "object.values": "^1.1.0",
+        "sax": "~1.2.4",
+        "stable": "^0.1.8",
+        "unquote": "~1.1.1",
+        "util.promisify": "~1.0.0"
+      },
+      "dependencies": {
+        "css-select": {
+          "version": "2.1.0",
+          "resolved": "https://registry.npmjs.org/css-select/-/css-select-2.1.0.tgz",
+          "integrity": "sha1-ajRlM1ZjWTSoG6ymjQJVQyEF2+8=",
+          "dev": true,
+          "requires": {
+            "boolbase": "^1.0.0",
+            "css-what": "^3.2.1",
+            "domutils": "^1.7.0",
+            "nth-check": "^1.0.2"
+          }
+        },
+        "css-what": {
+          "version": "3.3.0",
+          "resolved": "https://registry.npmjs.org/css-what/-/css-what-3.3.0.tgz",
+          "integrity": "sha1-EP7Glqns4uWRrHctdZqsq6w4zTk=",
+          "dev": true
+        },
+        "domelementtype": {
+          "version": "1.3.1",
+          "resolved": "https://registry.npmjs.org/domelementtype/-/domelementtype-1.3.1.tgz",
+          "integrity": "sha1-0EjESzew0Qp/Kj1f7j9DM9eQSB8=",
+          "dev": true
+        },
+        "domutils": {
+          "version": "1.7.0",
+          "resolved": "https://registry.npmjs.org/domutils/-/domutils-1.7.0.tgz",
+          "integrity": "sha1-Vuo0HoNOBuZ0ivehyyXaZ+qfjCo=",
+          "dev": true,
+          "requires": {
+            "dom-serializer": "0",
+            "domelementtype": "1"
+          }
+        }
       }
     },
     "tapable": {
@@ -7748,6 +11262,12 @@
         }
       }
     },
+    "text-hex": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/text-hex/-/text-hex-1.0.0.tgz",
+      "integrity": "sha1-adycGxdEbueakr9biEu0uRJ1BvU=",
+      "dev": true
+    },
     "through2": {
       "version": "2.0.5",
       "resolved": "https://registry.npmjs.org/through2/-/through2-2.0.5.tgz",
@@ -7791,6 +11311,24 @@
       "dev": true,
       "requires": {
         "setimmediate": "^1.0.4"
+      }
+    },
+    "tiny.js": {
+      "version": "0.2.4",
+      "resolved": "https://registry.npmjs.org/tiny.js/-/tiny.js-0.2.4.tgz",
+      "integrity": "sha1-CgZEYbsE0ju0fCVm4VtwHBFLjH0=",
+      "dev": true,
+      "requires": {
+        "inherits": "^2.0.1"
+      }
+    },
+    "tmp": {
+      "version": "0.0.33",
+      "resolved": "https://registry.npmjs.org/tmp/-/tmp-0.0.33.tgz",
+      "integrity": "sha1-bTQzWIl2jSGyvNoKonfO07G/rfk=",
+      "dev": true,
+      "requires": {
+        "os-tmpdir": "~1.0.2"
       }
     },
     "to-arraybuffer": {
@@ -7847,6 +11385,12 @@
         "repeat-string": "^1.6.1"
       }
     },
+    "toidentifier": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/toidentifier/-/toidentifier-1.0.0.tgz",
+      "integrity": "sha1-fhvjRw8ed5SLxD2Uo8j013UrpVM=",
+      "dev": true
+    },
     "tough-cookie": {
       "version": "2.5.0",
       "resolved": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-2.5.0.tgz",
@@ -7867,6 +11411,12 @@
       "integrity": "sha1-yy4SAwZ+DI3h9hQJS5/kVwTqYAM=",
       "dev": true
     },
+    "triple-beam": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/triple-beam/-/triple-beam-1.3.0.tgz",
+      "integrity": "sha1-pZUhTHKY24M57u7gg+TRC9jLjdk=",
+      "dev": true
+    },
     "true-case-path": {
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/true-case-path/-/true-case-path-1.0.3.tgz",
@@ -7879,6 +11429,12 @@
       "version": "1.13.0",
       "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.13.0.tgz",
       "integrity": "sha512-i/6DQjL8Xf3be4K/E6Wgpekn5Qasl1usyw++dAA35Ue5orEn65VIxOA+YvNNl9HV3qv70T7CNwjODHZrLwvd1Q==",
+      "dev": true
+    },
+    "tsscmp": {
+      "version": "1.0.6",
+      "resolved": "https://registry.npmjs.org/tsscmp/-/tsscmp-1.0.6.tgz",
+      "integrity": "sha1-hbmVg6w1iexL/vgltQAKqRHWBes=",
       "dev": true
     },
     "tty-browserify": {
@@ -7900,11 +11456,45 @@
       "resolved": "https://registry.npmjs.org/tweetnacl/-/tweetnacl-0.14.5.tgz",
       "integrity": "sha1-WuaBd/GS1EViadEIr6k/+HQ/T2Q="
     },
+    "type-check": {
+      "version": "0.3.2",
+      "resolved": "https://registry.npmjs.org/type-check/-/type-check-0.3.2.tgz",
+      "integrity": "sha1-WITKtRLPHTVeP7eE8wgEsrUg23I=",
+      "dev": true,
+      "requires": {
+        "prelude-ls": "~1.1.2"
+      }
+    },
+    "type-is": {
+      "version": "1.6.18",
+      "resolved": "https://registry.npmjs.org/type-is/-/type-is-1.6.18.tgz",
+      "integrity": "sha1-TlUs0F3wlGfcvE73Od6J8s83wTE=",
+      "dev": true,
+      "requires": {
+        "media-typer": "0.3.0",
+        "mime-types": "~2.1.24"
+      }
+    },
     "typedarray": {
       "version": "0.0.6",
       "resolved": "https://registry.npmjs.org/typedarray/-/typedarray-0.0.6.tgz",
       "integrity": "sha1-hnrHTjhkGHsdPUfZlqeOxciDB3c=",
       "dev": true
+    },
+    "ui-navigation": {
+      "version": "5.6.1",
+      "resolved": "http://registry.npm.ml.com/ui-navigation/-/ui-navigation-5.6.1.tgz",
+      "integrity": "sha1-hZKDbvMg990y2q70wEWaHwfzQ/s=",
+      "dev": true
+    },
+    "uid-safe": {
+      "version": "2.1.5",
+      "resolved": "https://registry.npmjs.org/uid-safe/-/uid-safe-2.1.5.tgz",
+      "integrity": "sha1-Kz1cckDo/C5Y+Komnl7knAhXvTo=",
+      "dev": true,
+      "requires": {
+        "random-bytes": "~1.0.0"
+      }
     },
     "unicode-canonical-property-names-ecmascript": {
       "version": "1.0.4",
@@ -7969,6 +11559,35 @@
       "requires": {
         "imurmurhash": "^0.1.4"
       }
+    },
+    "universalify": {
+      "version": "0.1.2",
+      "resolved": "https://registry.npmjs.org/universalify/-/universalify-0.1.2.tgz",
+      "integrity": "sha1-tkb2m+OULavOzJ1mOcgNwQXvqmY=",
+      "dev": true
+    },
+    "unix-dgram": {
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/unix-dgram/-/unix-dgram-2.0.4.tgz",
+      "integrity": "sha1-FNT8IeU5dCuPsCfeFuzNTlUDo0Q=",
+      "dev": true,
+      "optional": true,
+      "requires": {
+        "bindings": "^1.3.0",
+        "nan": "^2.13.2"
+      }
+    },
+    "unpipe": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/unpipe/-/unpipe-1.0.0.tgz",
+      "integrity": "sha1-sr9O6FFKrmFltIF4KdIbLvSZBOw=",
+      "dev": true
+    },
+    "unquote": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/unquote/-/unquote-1.1.1.tgz",
+      "integrity": "sha1-j97XMk7G6IoP+LkF58CYzcCG1UQ=",
+      "dev": true
     },
     "unset-value": {
       "version": "1.0.0",
@@ -8055,6 +11674,34 @@
       "integrity": "sha512-cwESVXlO3url9YWlFW/TA9cshCEhtu7IKJ/p5soJ/gGpj7vbvFrAY/eIioQ6Dw23KjZhYgiIo8HOs1nQ2vr/oQ==",
       "dev": true
     },
+    "useragent": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/useragent/-/useragent-2.3.0.tgz",
+      "integrity": "sha1-IX+UOtVAyyEoZYqyP8lg9qiMmXI=",
+      "dev": true,
+      "requires": {
+        "lru-cache": "4.1.x",
+        "tmp": "0.0.x"
+      },
+      "dependencies": {
+        "lru-cache": {
+          "version": "4.1.5",
+          "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-4.1.5.tgz",
+          "integrity": "sha1-i75Q6oW+1ZvJ4z3KuCNe6bz0Q80=",
+          "dev": true,
+          "requires": {
+            "pseudomap": "^1.0.2",
+            "yallist": "^2.1.2"
+          }
+        },
+        "yallist": {
+          "version": "2.1.2",
+          "resolved": "https://registry.npmjs.org/yallist/-/yallist-2.1.2.tgz",
+          "integrity": "sha1-HBH5IY8HYImkfdUS+TxmmaaoHVI=",
+          "dev": true
+        }
+      }
+    },
     "util": {
       "version": "0.11.1",
       "resolved": "https://registry.npmjs.org/util/-/util-0.11.1.tgz",
@@ -8093,6 +11740,12 @@
       "integrity": "sha1-ihagXURWV6Oupe7MWxKk+lN5dyw=",
       "dev": true
     },
+    "utils-merge": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/utils-merge/-/utils-merge-1.0.1.tgz",
+      "integrity": "sha1-n5VxD1CiZ5R7LMwSR0HBAoQn5xM=",
+      "dev": true
+    },
     "uuid": {
       "version": "3.4.0",
       "resolved": "https://registry.npmjs.org/uuid/-/uuid-3.4.0.tgz",
@@ -8127,6 +11780,12 @@
         "spdx-correct": "^3.0.0",
         "spdx-expression-parse": "^3.0.0"
       }
+    },
+    "vary": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/vary/-/vary-1.1.2.tgz",
+      "integrity": "sha1-IpnwLG3tMNSllhsLn3RSShj2NPw=",
+      "dev": true
     },
     "verror": {
       "version": "1.10.0",
@@ -8494,6 +12153,82 @@
         }
       }
     },
+    "window-size": {
+      "version": "0.1.4",
+      "resolved": "https://registry.npmjs.org/window-size/-/window-size-0.1.4.tgz",
+      "integrity": "sha1-+OGqHuWlPsW/FR/6CXQqatdpeHY=",
+      "dev": true
+    },
+    "winston": {
+      "version": "3.2.1",
+      "resolved": "https://registry.npmjs.org/winston/-/winston-3.2.1.tgz",
+      "integrity": "sha1-YwYTd5dsc1hAKL4kkKGEYFX3fwc=",
+      "dev": true,
+      "requires": {
+        "async": "^2.6.1",
+        "diagnostics": "^1.1.1",
+        "is-stream": "^1.1.0",
+        "logform": "^2.1.1",
+        "one-time": "0.0.4",
+        "readable-stream": "^3.1.1",
+        "stack-trace": "0.0.x",
+        "triple-beam": "^1.3.0",
+        "winston-transport": "^4.3.0"
+      },
+      "dependencies": {
+        "async": {
+          "version": "2.6.3",
+          "resolved": "https://registry.npmjs.org/async/-/async-2.6.3.tgz",
+          "integrity": "sha1-1yYl4jRKNlbjo61Pp0n6gymdgv8=",
+          "dev": true,
+          "requires": {
+            "lodash": "^4.17.14"
+          }
+        }
+      }
+    },
+    "winston-transport": {
+      "version": "4.4.0",
+      "resolved": "https://registry.npmjs.org/winston-transport/-/winston-transport-4.4.0.tgz",
+      "integrity": "sha1-F69RjappDVsuzMqnrPeyDKeSXlk=",
+      "dev": true,
+      "requires": {
+        "readable-stream": "^2.3.7",
+        "triple-beam": "^1.2.0"
+      },
+      "dependencies": {
+        "readable-stream": {
+          "version": "2.3.7",
+          "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.7.tgz",
+          "integrity": "sha1-Hsoc9xGu+BTAT2IlKjamL2yyO1c=",
+          "dev": true,
+          "requires": {
+            "core-util-is": "~1.0.0",
+            "inherits": "~2.0.3",
+            "isarray": "~1.0.0",
+            "process-nextick-args": "~2.0.0",
+            "safe-buffer": "~5.1.1",
+            "string_decoder": "~1.1.1",
+            "util-deprecate": "~1.0.1"
+          }
+        },
+        "string_decoder": {
+          "version": "1.1.1",
+          "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.1.1.tgz",
+          "integrity": "sha1-nPFhG6YmhdcDCunkujQUnDrwP8g=",
+          "dev": true,
+          "requires": {
+            "safe-buffer": "~5.1.0"
+          }
+        }
+      }
+    },
+    "word-wrap": {
+      "version": "1.2.3",
+      "resolved": "https://registry.npmjs.org/word-wrap/-/word-wrap-1.2.3.tgz",
+      "integrity": "sha1-YQY29rH3A4kb00dxzLF/uTtHB5w=",
+      "dev": true
+    },
     "worker-farm": {
       "version": "1.7.0",
       "resolved": "https://registry.npmjs.org/worker-farm/-/worker-farm-1.7.0.tgz",
@@ -8532,6 +12267,54 @@
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
       "integrity": "sha1-tSQ9jz7BqjXxNkYFvA0QNuMKtp8="
+    },
+    "x-xss-protection": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/x-xss-protection/-/x-xss-protection-1.3.0.tgz",
+      "integrity": "sha1-PjqN1jjagEIbDp//EaLb4Wj21Sw=",
+      "dev": true
+    },
+    "xml2js": {
+      "version": "0.4.23",
+      "resolved": "https://registry.npmjs.org/xml2js/-/xml2js-0.4.23.tgz",
+      "integrity": "sha1-oMaVFnUkIesqx1juTUzPWIQ+rGY=",
+      "dev": true,
+      "requires": {
+        "sax": ">=0.6.0",
+        "xmlbuilder": "~11.0.0"
+      },
+      "dependencies": {
+        "xmlbuilder": {
+          "version": "11.0.1",
+          "resolved": "https://registry.npmjs.org/xmlbuilder/-/xmlbuilder-11.0.1.tgz",
+          "integrity": "sha1-vpuuHIoEbnazESdyY0fQrXACvrM=",
+          "dev": true
+        }
+      }
+    },
+    "xmlbuilder": {
+      "version": "13.0.2",
+      "resolved": "https://registry.npmjs.org/xmlbuilder/-/xmlbuilder-13.0.2.tgz",
+      "integrity": "sha1-Aq4zYUtqBH0cMrU4nB/ayyvOR6c=",
+      "dev": true
+    },
+    "xss": {
+      "version": "1.0.6",
+      "resolved": "https://registry.npmjs.org/xss/-/xss-1.0.6.tgz",
+      "integrity": "sha1-6vEen8R2464omUShAJ793YoSS1E=",
+      "dev": true,
+      "requires": {
+        "commander": "^2.9.0",
+        "cssfilter": "0.0.10"
+      },
+      "dependencies": {
+        "commander": {
+          "version": "2.20.3",
+          "resolved": "https://registry.npmjs.org/commander/-/commander-2.20.3.tgz",
+          "integrity": "sha1-/UhehMA+tIgcIHIrpIA16FMa6zM=",
+          "dev": true
+        }
+      }
     },
     "xtend": {
       "version": "4.0.2",
@@ -8573,6 +12356,25 @@
       "requires": {
         "camelcase": "^5.0.0",
         "decamelize": "^1.2.0"
+      }
+    },
+    "youch": {
+      "version": "2.0.10",
+      "resolved": "https://registry.npmjs.org/youch/-/youch-2.0.10.tgz",
+      "integrity": "sha1-4PYxKxIwT9MwoMSg4JJbASP31JU=",
+      "dev": true,
+      "requires": {
+        "cookie": "^0.3.1",
+        "mustache": "^3.0.0",
+        "stack-trace": "0.0.10"
+      },
+      "dependencies": {
+        "cookie": {
+          "version": "0.3.1",
+          "resolved": "https://registry.npmjs.org/cookie/-/cookie-0.3.1.tgz",
+          "integrity": "sha1-5+Ch+e9DtMi6klxcWpboBtFoc7s=",
+          "dev": true
+        }
       }
     }
   }

--- a/package.json
+++ b/package.json
@@ -4,6 +4,9 @@
   "description": "project to test random thoughts",
   "main": "index.js",
   "scripts": {
+    "i18n:gettext": "i18n gettext",
+    "i18n:upload": "i18n upload",
+    "i18n:download": "i18n download --path ./translations",
     "test": "echo \"Error: no test specified\" && exit 1"
   },
   "author": "goexrois@gmail.com",
@@ -26,6 +29,7 @@
     "html-webpack-inline-style-plugin": "^0.2.0",
     "html-webpack-plugin": "^4.3.0",
     "loader-utils": "^2.0.0",
+    "nordic": "6.2.0",
     "raw-loader": "^4.0.1",
     "react-dom": "^16.13.1",
     "require-from-string": "^2.0.2",

--- a/src/templates/one/content.js
+++ b/src/templates/one/content.js
@@ -1,0 +1,37 @@
+const I18n = require('frontend-i18n');
+
+const getTranslationsForSite = siteId => {
+  let filePath = '../../../translations/';
+  switch (siteId) {
+    case 'MLA':
+      filePath += 'es-AR/';
+      break;
+    case 'MLB':
+      filePath += 'pt-BR/';
+      break;
+    default:
+      break;
+  }
+
+  filePath += 'messages.json';
+
+  let translations = require(filePath);
+  return translations;
+};
+
+const getContent = siteId => {
+  const translations = getTranslationsForSite(siteId);
+
+  const i18n = new I18n({
+    translations,
+  });
+
+  const content = {
+    title: i18n.gettext('Un titulo muy apropiado'),
+    mlbText: i18n.gettext('Dame tu CCB, maldito'),
+  };
+
+  return content;
+};
+
+module.exports = siteId => getContent(siteId);

--- a/src/templates/one/index.js
+++ b/src/templates/one/index.js
@@ -1,12 +1,31 @@
 const React = require('react');
 const If = require('../../../components/dist/If');
+const getContent = require('./content');
 
-const TemplateOne = env => (
-  <div className="template-one">
-    <If env={env} condition={2 === 2}>
-      <div className="inner-div">Holas</div>
-    </If>
-  </div>
-);
+const TemplateOne = (env, siteId) => {
+  const CONTENT = getContent(siteId);
 
-module.exports = env => TemplateOne(env);
+  return (
+    <table cellPadding={0} cellSpacing={0}>
+      <tr>
+        <td>
+          <p>{CONTENT.title}</p>
+        </td>
+        {siteId === 'MLB' && (
+          <td>
+            <p>This is in only for MLB: {CONTENT.mlbText}</p>
+          </td>
+        )}
+        <td>
+          <div className="template-one">
+            <If env={env} condition={2 === 2}>
+              <div className="inner-div">Holas</div>
+            </If>
+          </div>
+        </td>
+      </tr>
+    </table>
+  );
+};
+
+module.exports = (env, siteId) => TemplateOne(env, siteId);

--- a/translations/es-AR/messages.json
+++ b/translations/es-AR/messages.json
@@ -1,0 +1,1 @@
+{"Un titulo muy apropiado":[null,"Un titulo muy apropiado AR"]}

--- a/translations/es-MX/messages.json
+++ b/translations/es-MX/messages.json
@@ -1,0 +1,1 @@
+{"Un titulo muy apropiado":[null,"Un titulo muy apropiado MX"]}

--- a/translations/messages.json
+++ b/translations/messages.json
@@ -1,0 +1,1 @@
+{"Un titulo muy apropiado":[null,""],"Dame tu CCB, maldito":[null,""]}

--- a/translations/pt-BR/messages.json
+++ b/translations/pt-BR/messages.json
@@ -1,0 +1,1 @@
+{"Un titulo muy apropiado":[null,"Un titulinho muito apropiado"],"Dame tu CCB, maldito":[null,"Dame tu CCB, maldito BR"]}

--- a/webpack_utils/reactRenderLoader.js
+++ b/webpack_utils/reactRenderLoader.js
@@ -20,7 +20,7 @@ module.exports = function loader(source) {
   const module = requireFromString(code, this.resourcePath);
   console.log('module', module);
 
-  const component = module(env);
+  const component = module(env, 'MLB');
   console.log('component', component);
 
   const renderedComponent = renderer.renderToStaticMarkup(component)


### PR DESCRIPTION
Based on #1 

The idea is to use Nordic's i18n to manage content translation as in web frontends. And use `siteId` as a prop to show/hide specific content.

Missing: make webpack produce a folder for each site with its generated template.

#### How to try it
1 - `cd /components; npm install; npx webpack;`
2 - `cd ..; npm install; npx webpack --env development`